### PR TITLE
fix: make `validateDefinition` non-distributive

### DIFF
--- a/src/parse/definition.ts
+++ b/src/parse/definition.ts
@@ -83,20 +83,24 @@ export type inferDefinition<def, $> = isAny<def> extends true
     : never
 
 // we ignore functions in validation so that cyclic thunk definitions can be inferred in scopes
-export type validateDefinition<def, $> = def extends (...args: any[]) => any
+export type validateDefinition<def, $> = [def] extends [(...args: any[]) => any]
     ? def
-    : def extends Terminal
+    : [def] extends [Terminal]
     ? def
-    : def extends string
+    : [def] extends [string]
     ? validateString<def, $>
-    : def extends TupleExpression
+    : [def] extends [TupleExpression]
     ? validateTupleExpression<def, $>
-    : def extends BadDefinitionType
+    : [def] extends [BadDefinitionType]
     ? writeBadDefinitionTypeMessage<
           objectKindOf<def> extends string ? objectKindOf<def> : domainOf<def>
       >
     : isUnknown<def> extends true
     ? unknownDefinitionMessage
+    : [def] extends [readonly unknown[]]
+    ? {
+          [k in keyof def]: validateDefinition<def[k], $>
+      }
     : evaluate<{
           [k in keyof def]: validateDefinition<def[k], $>
       }>


### PR DESCRIPTION
This fixes the discussed problem with `typescript@5.1.0-dev.20230311` but I'm not entirely sure if it's the correct fix for everything. I wonder what your tests might tell about it.