### PR TITLE
fix: check all keys when in strict or distilled mode, even if one fails

### DIFF
--- a/dev/configs/.changeset/tricky-terms-worry.md
+++ b/dev/configs/.changeset/tricky-terms-worry.md
@@ -1,0 +1,5 @@
+---
+"arktype": patch
+---
+
+check all keys when in strict or distilled mode, even if one fails

--- a/dev/test/record.test.ts
+++ b/dev/test/record.test.ts
@@ -62,4 +62,10 @@ describe("record", () => {
             }
         })
     })
+    it("multiple bad strict", () => {
+        const t = type({ a: "string", b: "boolean" }, { keys: "strict" })
+        attest(t({ a: 1, b: 2 }).problems?.summary).snap(
+            "a must be a string (was number)\nb must be boolean (was number)"
+        )
+    })
 })

--- a/src/traverse/traverse.ts
+++ b/src/traverse/traverse.ts
@@ -241,10 +241,10 @@ const createPropChecker =
         const remainingUnseenRequired = { ...props.required }
         for (const k in state.data) {
             if (props.required[k]) {
-                isValid &&= state.traverseKey(k, props.required[k])
+                isValid = state.traverseKey(k, props.required[k]) && isValid
                 delete remainingUnseenRequired[k]
             } else if (props.optional[k]) {
-                isValid &&= state.traverseKey(k, props.optional[k])
+                isValid = state.traverseKey(k, props.optional[k]) && isValid
             } else if (kind === "distilledProps") {
                 if (state.failFast) {
                     // If we're in a union (i.e. failFast is enabled) in


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
