### PR TITLE
docs: consistently quote props for editing 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Install dependencies and perform setup for https://github.com/arkty
 
 inputs:
     node:
-        default: lts/*
+        default: latest
 
 runs:
     using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
         - name: Setup pnpm
           uses: pnpm/action-setup@v2
           with:
-              version: 7.32.2
+              version: 8.3.1
 
         - name: Setup Node (${{ inputs.node }})
           uses: actions/setup-node@v3

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
         - name: Setup pnpm
           uses: pnpm/action-setup@v2
           with:
-              version: 7.1.2
+              version: 7.32.2
 
         - name: Setup Node (${{ inputs.node }})
           uses: actions/setup-node@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,9 @@ jobs:
             - name: Setup repo
               uses: ./.github/actions/setup
 
+            - name: Typecheck
+              run: pnpm typecheck
+
             - name: Lint
               run: pnpm lint
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,13 +38,8 @@ jobs:
         timeout-minutes: 20
         strategy:
             matrix:
-                node: [lts/*]
-                os: [windows-latest, macos-latest]
-                include:
-                    - os: ubuntu-latest
-                      node: lts/-1
-                    - os: ubuntu-latest
-                      node: latest
+                node: [14, 16, 18, 19, 20]
+                os: [ubuntu-latest, windows-latest, macos-latest]
 
         runs-on: ${{ matrix.os }}
         steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,9 @@ jobs:
             - name: Lint
               run: pnpm lint
 
+            - name: Format
+              run: pnpm exec prettier --check --ignore-path ./dev/configs/.prettierignore .
+
             - name: Test
               run: pnpm testRepo
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import { type } from "../../src/main.js"
 export const user = type({
     name: "string",
     device: {
-        platform: "'android'|'ios'",
+        "platform": "'android'|'ios'",
         "version?": "number"
     }
 })
@@ -70,13 +70,13 @@ import { scope } from "../../src/main.js"
 // Scopes are collections of types that can reference each other.
 export const types = scope({
     package: {
-        name: "string",
+        "name": "string",
         "dependencies?": "package[]",
         "contributors?": "contributor[]"
     },
     contributor: {
         // Subtypes like 'email' are inferred like 'string' but provide additional validation at runtime.
-        email: "email",
+        "email": "email",
         "packages?": "package[]"
     }
 }).compile()

--- a/dev/arktype.io/docs/api/narrow.md
+++ b/dev/arktype.io/docs/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--                                const isEven = (x: unknown): x is number => x % 2 === 0
+-                                                            const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/docs/api/narrow.md
+++ b/dev/arktype.io/docs/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--            const isEven = (x: unknown): x is number => x % 2 === 0
+-                                const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/docs/demos/stackblitzGenerators/createStackblitzDemo.ts
+++ b/dev/arktype.io/docs/demos/stackblitzGenerators/createStackblitzDemo.ts
@@ -30,6 +30,7 @@ export const createStackblitzDemo = async ({ embedId }: DemoProps) =>
                 ".prettierrc": JSON.stringify({
                     tabWidth: 4,
                     semi: false,
+                    quoteProps: "consistent",
                     trailingComma: "none"
                 }),
                 ...defaultStaticFiles

--- a/dev/arktype.io/src/components/homeDemo.tsx
+++ b/dev/arktype.io/src/components/homeDemo.tsx
@@ -21,18 +21,18 @@ export const HomeDemo = () => {
                 variant="contained"
                 sx={{
                     backgroundColor,
-                    backdropFilter: "blur(4px)",
-                    borderRadius: "2rem",
-                    fontSize: "1.5rem",
-                    fontFamily: cascadiaCodeFamily,
-                    textTransform: "none",
-                    color: palette.primary.main,
+                    "backdropFilter": "blur(4px)",
+                    "borderRadius": "2rem",
+                    "fontSize": "1.5rem",
+                    "fontFamily": cascadiaCodeFamily,
+                    "textTransform": "none",
+                    "color": palette.primary.main,
                     "&:hover": {
                         backgroundColor,
                         color: palette.secondary.main,
                         backdropFilter: "blur(6px)"
                     },
-                    zIndex: 1
+                    "zIndex": 1
                 }}
                 onClick={() => setIsActive(!isActive)}
                 endIcon={

--- a/dev/arktype.io/versioned_docs/version-1.0.11-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.11-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--                                      const isEven = (x: unknown): x is number => x % 2 === 0
+-                                                                  const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.11-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.11-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--                  const isEven = (x: unknown): x is number => x % 2 === 0
+-                                      const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.12-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.12-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--                                    const isEven = (x: unknown): x is number => x % 2 === 0
+-                                                                const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.12-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.12-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--                const isEven = (x: unknown): x is number => x % 2 === 0
+-                                    const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.12-alpha/demos/stackblitzGenerators/createStackblitzDemo.ts
+++ b/dev/arktype.io/versioned_docs/version-1.0.12-alpha/demos/stackblitzGenerators/createStackblitzDemo.ts
@@ -30,6 +30,7 @@ export const createStackblitzDemo = async ({ embedId }: DemoProps) =>
                 ".prettierrc": JSON.stringify({
                     tabWidth: 4,
                     semi: false,
+                    quoteProps: "consistent",
                     trailingComma: "none"
                 }),
                 ...defaultStaticFiles

--- a/dev/arktype.io/versioned_docs/version-1.0.13-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.13-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--              const isEven = (x: unknown): x is number => x % 2 === 0
+-                                  const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.13-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.13-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--                                  const isEven = (x: unknown): x is number => x % 2 === 0
+-                                                              const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.13-alpha/demos/stackblitzGenerators/createStackblitzDemo.ts
+++ b/dev/arktype.io/versioned_docs/version-1.0.13-alpha/demos/stackblitzGenerators/createStackblitzDemo.ts
@@ -30,6 +30,7 @@ export const createStackblitzDemo = async ({ embedId }: DemoProps) =>
                 ".prettierrc": JSON.stringify({
                     tabWidth: 4,
                     semi: false,
+                    quoteProps: "consistent",
                     trailingComma: "none"
                 }),
                 ...defaultStaticFiles

--- a/dev/arktype.io/versioned_docs/version-1.0.14-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.14-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--                                const isEven = (x: unknown): x is number => x % 2 === 0
+-                                                            const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.14-alpha/api/narrow.md
+++ b/dev/arktype.io/versioned_docs/version-1.0.14-alpha/api/narrow.md
@@ -15,4 +15,4 @@ hide_table_of_contents: true
 
 ## example
 
--            const isEven = (x: unknown): x is number => x % 2 === 0
+-                                const isEven = (x: unknown): x is number => x % 2 === 0

--- a/dev/arktype.io/versioned_docs/version-1.0.14-alpha/demos/stackblitzGenerators/createStackblitzDemo.ts
+++ b/dev/arktype.io/versioned_docs/version-1.0.14-alpha/demos/stackblitzGenerators/createStackblitzDemo.ts
@@ -30,6 +30,7 @@ export const createStackblitzDemo = async ({ embedId }: DemoProps) =>
                 ".prettierrc": JSON.stringify({
                     tabWidth: 4,
                     semi: false,
+                    quoteProps: "consistent",
                     trailingComma: "none"
                 }),
                 ...defaultStaticFiles

--- a/dev/configs/.eslintrc.cjs
+++ b/dev/configs/.eslintrc.cjs
@@ -26,8 +26,8 @@ module.exports = defineConfig({
         /**
          * General restrictions
          */
-        curly: "warn",
-        eqeqeq: "warn",
+        "curly": "warn",
+        "eqeqeq": "warn",
         "object-shorthand": ["warn"],
         "@typescript-eslint/no-unused-vars": [
             "warn",

--- a/dev/examples/concision.ts
+++ b/dev/examples/concision.ts
@@ -5,16 +5,16 @@ import type { Infer } from "../../src/main.js"
 {
     // @snipStatement:arkUserExpression
     const arkUser = type({
-        name: /^ark.*$/ as Infer<`ark${string}`>,
-        birthday: ["string", "|>", (s) => new Date(s)],
+        "name": /^ark.*$/ as Infer<`ark${string}`>,
+        "birthday": ["string", "|>", (s) => new Date(s)],
         "powerLevel?": "1<=number<9000"
     })
 }
 
 // @snipStatement:arkUserHelper
 const arkUser = type({
-    name: /^ark.*$/ as Infer<`ark${string}`>,
-    birthday: morph("string", (s) => new Date(s)),
+    "name": /^ark.*$/ as Infer<`ark${string}`>,
+    "birthday": morph("string", (s) => new Date(s)),
     "powerLevel?": "1<=number<9000"
 })
 

--- a/dev/examples/demo.ts
+++ b/dev/examples/demo.ts
@@ -2,8 +2,8 @@ import { type } from "../../src/main.js"
 
 // Define your type...
 export const pkg = type({
-    name: "string",
-    version: "semver",
+    "name": "string",
+    "version": "semver",
     "contributors?": "1<email[]<=10"
 })
 

--- a/dev/examples/scope.ts
+++ b/dev/examples/scope.ts
@@ -3,13 +3,13 @@ import { scope } from "../../src/main.js"
 // Scopes are collections of types that can reference each other.
 export const types = scope({
     package: {
-        name: "string",
+        "name": "string",
         "dependencies?": "package[]",
         "contributors?": "contributor[]"
     },
     contributor: {
         // Subtypes like 'email' are inferred like 'string' but provide additional validation at runtime.
-        email: "email",
+        "email": "email",
         "packages?": "package[]"
     }
 }).compile()

--- a/dev/examples/type.ts
+++ b/dev/examples/type.ts
@@ -4,7 +4,7 @@ import { type } from "../../src/main.js"
 export const user = type({
     name: "string",
     device: {
-        platform: "'android'|'ios'",
+        "platform": "'android'|'ios'",
         "version?": "number"
     }
 })

--- a/dev/test/cyclic.test.ts
+++ b/dev/test/cyclic.test.ts
@@ -5,12 +5,12 @@ import { attest } from "../attest/main.js"
 const getCyclicScope = () =>
     scope({
         package: {
-            name: "string",
+            "name": "string",
             "dependencies?": "package[]",
             "contributors?": "contributor[]"
         },
         contributor: {
-            email: "email",
+            "email": "email",
             "packages?": "package[]"
         }
     })

--- a/dev/test/discriminate.test.ts
+++ b/dev/test/discriminate.test.ts
@@ -152,7 +152,7 @@ describe("discriminate", () => {
                                 ["isRainForest", [["value", true]]]
                             ]
                         ],
-                        default: [
+                        "default": [
                             [
                                 "requiredProp",
                                 ["temperature", [["value", "hot"]]]
@@ -179,7 +179,7 @@ describe("discriminate", () => {
                     cases: {
                         "'cold'": [],
                         "'hot'": [],
-                        default: [
+                        "default": [
                             [
                                 "switch",
                                 {

--- a/dev/test/generateBenchData.ts
+++ b/dev/test/generateBenchData.ts
@@ -6,9 +6,9 @@ const randomInRange = (min: number, max: number) =>
 
 const cyclicScopeSeed = Object.freeze({
     user: {
-        name: "string",
+        "name": "string",
         "friends?": "user[]",
-        groups: "group[]"
+        "groups": "group[]"
     },
     group: {
         title: "string",

--- a/dev/test/generated/cyclic.ts
+++ b/dev/test/generated/cyclic.ts
@@ -1,28 +1,28 @@
 export const cyclic10 = {
     user: {
-        name: "string",
+        "name": "string",
         "friends?": "user[]",
-        groups: "group[]"
+        "groups": "group[]"
     },
     user2: {
-        name2: "string",
+        "name2": "string",
         "friends2?": "user3[]",
-        groups2: "group3[]"
+        "groups2": "group3[]"
     },
     user3: {
-        name3: "string",
+        "name3": "string",
         "friends3?": "user2[]",
-        groups3: "group5[]"
+        "groups3": "group5[]"
     },
     user4: {
-        name4: "string",
+        "name4": "string",
         "friends4?": "user5[]",
-        groups4: "group2[]"
+        "groups4": "group2[]"
     },
     user5: {
-        name5: "string",
+        "name5": "string",
         "friends5?": "user3[]",
-        groups5: "group3[]"
+        "groups5": "group3[]"
     },
     group: {
         title: "string",
@@ -53,254 +53,254 @@ export const cyclic10 = {
 
 export const cyclic100 = {
     user: {
-        name: "string",
+        "name": "string",
         "friends?": "user[]",
-        groups: "group[]"
+        "groups": "group[]"
     },
     user2: {
-        name2: "string",
+        "name2": "string",
         "friends2?": "user33[]",
-        groups2: "group38[]"
+        "groups2": "group38[]"
     },
     user3: {
-        name3: "string",
+        "name3": "string",
         "friends3?": "user30[]",
-        groups3: "group43[]"
+        "groups3": "group43[]"
     },
     user4: {
-        name4: "string",
+        "name4": "string",
         "friends4?": "user2[]",
-        groups4: "group7[]"
+        "groups4": "group7[]"
     },
     user5: {
-        name5: "string",
+        "name5": "string",
         "friends5?": "user21[]",
-        groups5: "group9[]"
+        "groups5": "group9[]"
     },
     user6: {
-        name6: "string",
+        "name6": "string",
         "friends6?": "user14[]",
-        groups6: "group30[]"
+        "groups6": "group30[]"
     },
     user7: {
-        name7: "string",
+        "name7": "string",
         "friends7?": "user16[]",
-        groups7: "group20[]"
+        "groups7": "group20[]"
     },
     user8: {
-        name8: "string",
+        "name8": "string",
         "friends8?": "user27[]",
-        groups8: "group8[]"
+        "groups8": "group8[]"
     },
     user9: {
-        name9: "string",
+        "name9": "string",
         "friends9?": "user33[]",
-        groups9: "group38[]"
+        "groups9": "group38[]"
     },
     user10: {
-        name10: "string",
+        "name10": "string",
         "friends10?": "user11[]",
-        groups10: "group50[]"
+        "groups10": "group50[]"
     },
     user11: {
-        name11: "string",
+        "name11": "string",
         "friends11?": "user47[]",
-        groups11: "group46[]"
+        "groups11": "group46[]"
     },
     user12: {
-        name12: "string",
+        "name12": "string",
         "friends12?": "user44[]",
-        groups12: "group8[]"
+        "groups12": "group8[]"
     },
     user13: {
-        name13: "string",
+        "name13": "string",
         "friends13?": "user29[]",
-        groups13: "group25[]"
+        "groups13": "group25[]"
     },
     user14: {
-        name14: "string",
+        "name14": "string",
         "friends14?": "user35[]",
-        groups14: "group48[]"
+        "groups14": "group48[]"
     },
     user15: {
-        name15: "string",
+        "name15": "string",
         "friends15?": "user29[]",
-        groups15: "group27[]"
+        "groups15": "group27[]"
     },
     user16: {
-        name16: "string",
+        "name16": "string",
         "friends16?": "user16[]",
-        groups16: "group2[]"
+        "groups16": "group2[]"
     },
     user17: {
-        name17: "string",
+        "name17": "string",
         "friends17?": "user28[]",
-        groups17: "group45[]"
+        "groups17": "group45[]"
     },
     user18: {
-        name18: "string",
+        "name18": "string",
         "friends18?": "user16[]",
-        groups18: "group29[]"
+        "groups18": "group29[]"
     },
     user19: {
-        name19: "string",
+        "name19": "string",
         "friends19?": "user41[]",
-        groups19: "group39[]"
+        "groups19": "group39[]"
     },
     user20: {
-        name20: "string",
+        "name20": "string",
         "friends20?": "user6[]",
-        groups20: "group10[]"
+        "groups20": "group10[]"
     },
     user21: {
-        name21: "string",
+        "name21": "string",
         "friends21?": "user29[]",
-        groups21: "group48[]"
+        "groups21": "group48[]"
     },
     user22: {
-        name22: "string",
+        "name22": "string",
         "friends22?": "user42[]",
-        groups22: "group34[]"
+        "groups22": "group34[]"
     },
     user23: {
-        name23: "string",
+        "name23": "string",
         "friends23?": "user48[]",
-        groups23: "group13[]"
+        "groups23": "group13[]"
     },
     user24: {
-        name24: "string",
+        "name24": "string",
         "friends24?": "user7[]",
-        groups24: "group30[]"
+        "groups24": "group30[]"
     },
     user25: {
-        name25: "string",
+        "name25": "string",
         "friends25?": "user44[]",
-        groups25: "group46[]"
+        "groups25": "group46[]"
     },
     user26: {
-        name26: "string",
+        "name26": "string",
         "friends26?": "user27[]",
-        groups26: "group27[]"
+        "groups26": "group27[]"
     },
     user27: {
-        name27: "string",
+        "name27": "string",
         "friends27?": "user43[]",
-        groups27: "group28[]"
+        "groups27": "group28[]"
     },
     user28: {
-        name28: "string",
+        "name28": "string",
         "friends28?": "user21[]",
-        groups28: "group40[]"
+        "groups28": "group40[]"
     },
     user29: {
-        name29: "string",
+        "name29": "string",
         "friends29?": "user14[]",
-        groups29: "group4[]"
+        "groups29": "group4[]"
     },
     user30: {
-        name30: "string",
+        "name30": "string",
         "friends30?": "user7[]",
-        groups30: "group33[]"
+        "groups30": "group33[]"
     },
     user31: {
-        name31: "string",
+        "name31": "string",
         "friends31?": "user29[]",
-        groups31: "group29[]"
+        "groups31": "group29[]"
     },
     user32: {
-        name32: "string",
+        "name32": "string",
         "friends32?": "user4[]",
-        groups32: "group44[]"
+        "groups32": "group44[]"
     },
     user33: {
-        name33: "string",
+        "name33": "string",
         "friends33?": "user37[]",
-        groups33: "group13[]"
+        "groups33": "group13[]"
     },
     user34: {
-        name34: "string",
+        "name34": "string",
         "friends34?": "user39[]",
-        groups34: "group49[]"
+        "groups34": "group49[]"
     },
     user35: {
-        name35: "string",
+        "name35": "string",
         "friends35?": "user36[]",
-        groups35: "group43[]"
+        "groups35": "group43[]"
     },
     user36: {
-        name36: "string",
+        "name36": "string",
         "friends36?": "user11[]",
-        groups36: "group31[]"
+        "groups36": "group31[]"
     },
     user37: {
-        name37: "string",
+        "name37": "string",
         "friends37?": "user11[]",
-        groups37: "group29[]"
+        "groups37": "group29[]"
     },
     user38: {
-        name38: "string",
+        "name38": "string",
         "friends38?": "user35[]",
-        groups38: "group12[]"
+        "groups38": "group12[]"
     },
     user39: {
-        name39: "string",
+        "name39": "string",
         "friends39?": "user21[]",
-        groups39: "group17[]"
+        "groups39": "group17[]"
     },
     user40: {
-        name40: "string",
+        "name40": "string",
         "friends40?": "user11[]",
-        groups40: "group22[]"
+        "groups40": "group22[]"
     },
     user41: {
-        name41: "string",
+        "name41": "string",
         "friends41?": "user32[]",
-        groups41: "group48[]"
+        "groups41": "group48[]"
     },
     user42: {
-        name42: "string",
+        "name42": "string",
         "friends42?": "user39[]",
-        groups42: "group10[]"
+        "groups42": "group10[]"
     },
     user43: {
-        name43: "string",
+        "name43": "string",
         "friends43?": "user19[]",
-        groups43: "group6[]"
+        "groups43": "group6[]"
     },
     user44: {
-        name44: "string",
+        "name44": "string",
         "friends44?": "user8[]",
-        groups44: "group22[]"
+        "groups44": "group22[]"
     },
     user45: {
-        name45: "string",
+        "name45": "string",
         "friends45?": "user31[]",
-        groups45: "group47[]"
+        "groups45": "group47[]"
     },
     user46: {
-        name46: "string",
+        "name46": "string",
         "friends46?": "user33[]",
-        groups46: "group42[]"
+        "groups46": "group42[]"
     },
     user47: {
-        name47: "string",
+        "name47": "string",
         "friends47?": "user20[]",
-        groups47: "group10[]"
+        "groups47": "group10[]"
     },
     user48: {
-        name48: "string",
+        "name48": "string",
         "friends48?": "user23[]",
-        groups48: "group45[]"
+        "groups48": "group45[]"
     },
     user49: {
-        name49: "string",
+        "name49": "string",
         "friends49?": "user42[]",
-        groups49: "group39[]"
+        "groups49": "group39[]"
     },
     user50: {
-        name50: "string",
+        "name50": "string",
         "friends50?": "user37[]",
-        groups50: "group21[]"
+        "groups50": "group21[]"
     },
     group: {
         title: "string",
@@ -556,1254 +556,1254 @@ export const cyclic100 = {
 
 export const cyclic500 = {
     user: {
-        name: "string",
+        "name": "string",
         "friends?": "user[]",
-        groups: "group[]"
+        "groups": "group[]"
     },
     user2: {
-        name2: "string",
+        "name2": "string",
         "friends2?": "user124[]",
-        groups2: "group85[]"
+        "groups2": "group85[]"
     },
     user3: {
-        name3: "string",
+        "name3": "string",
         "friends3?": "user130[]",
-        groups3: "group159[]"
+        "groups3": "group159[]"
     },
     user4: {
-        name4: "string",
+        "name4": "string",
         "friends4?": "user238[]",
-        groups4: "group171[]"
+        "groups4": "group171[]"
     },
     user5: {
-        name5: "string",
+        "name5": "string",
         "friends5?": "user22[]",
-        groups5: "group13[]"
+        "groups5": "group13[]"
     },
     user6: {
-        name6: "string",
+        "name6": "string",
         "friends6?": "user107[]",
-        groups6: "group18[]"
+        "groups6": "group18[]"
     },
     user7: {
-        name7: "string",
+        "name7": "string",
         "friends7?": "user194[]",
-        groups7: "group6[]"
+        "groups7": "group6[]"
     },
     user8: {
-        name8: "string",
+        "name8": "string",
         "friends8?": "user226[]",
-        groups8: "group26[]"
+        "groups8": "group26[]"
     },
     user9: {
-        name9: "string",
+        "name9": "string",
         "friends9?": "user193[]",
-        groups9: "group108[]"
+        "groups9": "group108[]"
     },
     user10: {
-        name10: "string",
+        "name10": "string",
         "friends10?": "user194[]",
-        groups10: "group242[]"
+        "groups10": "group242[]"
     },
     user11: {
-        name11: "string",
+        "name11": "string",
         "friends11?": "user11[]",
-        groups11: "group67[]"
+        "groups11": "group67[]"
     },
     user12: {
-        name12: "string",
+        "name12": "string",
         "friends12?": "user240[]",
-        groups12: "group10[]"
+        "groups12": "group10[]"
     },
     user13: {
-        name13: "string",
+        "name13": "string",
         "friends13?": "user213[]",
-        groups13: "group11[]"
+        "groups13": "group11[]"
     },
     user14: {
-        name14: "string",
+        "name14": "string",
         "friends14?": "user63[]",
-        groups14: "group157[]"
+        "groups14": "group157[]"
     },
     user15: {
-        name15: "string",
+        "name15": "string",
         "friends15?": "user48[]",
-        groups15: "group244[]"
+        "groups15": "group244[]"
     },
     user16: {
-        name16: "string",
+        "name16": "string",
         "friends16?": "user21[]",
-        groups16: "group72[]"
+        "groups16": "group72[]"
     },
     user17: {
-        name17: "string",
+        "name17": "string",
         "friends17?": "user160[]",
-        groups17: "group115[]"
+        "groups17": "group115[]"
     },
     user18: {
-        name18: "string",
+        "name18": "string",
         "friends18?": "user46[]",
-        groups18: "group166[]"
+        "groups18": "group166[]"
     },
     user19: {
-        name19: "string",
+        "name19": "string",
         "friends19?": "user217[]",
-        groups19: "group165[]"
+        "groups19": "group165[]"
     },
     user20: {
-        name20: "string",
+        "name20": "string",
         "friends20?": "user163[]",
-        groups20: "group182[]"
+        "groups20": "group182[]"
     },
     user21: {
-        name21: "string",
+        "name21": "string",
         "friends21?": "user177[]",
-        groups21: "group178[]"
+        "groups21": "group178[]"
     },
     user22: {
-        name22: "string",
+        "name22": "string",
         "friends22?": "user140[]",
-        groups22: "group70[]"
+        "groups22": "group70[]"
     },
     user23: {
-        name23: "string",
+        "name23": "string",
         "friends23?": "user120[]",
-        groups23: "group12[]"
+        "groups23": "group12[]"
     },
     user24: {
-        name24: "string",
+        "name24": "string",
         "friends24?": "user33[]",
-        groups24: "group18[]"
+        "groups24": "group18[]"
     },
     user25: {
-        name25: "string",
+        "name25": "string",
         "friends25?": "user91[]",
-        groups25: "group226[]"
+        "groups25": "group226[]"
     },
     user26: {
-        name26: "string",
+        "name26": "string",
         "friends26?": "user43[]",
-        groups26: "group230[]"
+        "groups26": "group230[]"
     },
     user27: {
-        name27: "string",
+        "name27": "string",
         "friends27?": "user34[]",
-        groups27: "group49[]"
+        "groups27": "group49[]"
     },
     user28: {
-        name28: "string",
+        "name28": "string",
         "friends28?": "user46[]",
-        groups28: "group100[]"
+        "groups28": "group100[]"
     },
     user29: {
-        name29: "string",
+        "name29": "string",
         "friends29?": "user20[]",
-        groups29: "group250[]"
+        "groups29": "group250[]"
     },
     user30: {
-        name30: "string",
+        "name30": "string",
         "friends30?": "user56[]",
-        groups30: "group100[]"
+        "groups30": "group100[]"
     },
     user31: {
-        name31: "string",
+        "name31": "string",
         "friends31?": "user215[]",
-        groups31: "group169[]"
+        "groups31": "group169[]"
     },
     user32: {
-        name32: "string",
+        "name32": "string",
         "friends32?": "user65[]",
-        groups32: "group247[]"
+        "groups32": "group247[]"
     },
     user33: {
-        name33: "string",
+        "name33": "string",
         "friends33?": "user192[]",
-        groups33: "group38[]"
+        "groups33": "group38[]"
     },
     user34: {
-        name34: "string",
+        "name34": "string",
         "friends34?": "user147[]",
-        groups34: "group102[]"
+        "groups34": "group102[]"
     },
     user35: {
-        name35: "string",
+        "name35": "string",
         "friends35?": "user140[]",
-        groups35: "group47[]"
+        "groups35": "group47[]"
     },
     user36: {
-        name36: "string",
+        "name36": "string",
         "friends36?": "user168[]",
-        groups36: "group185[]"
+        "groups36": "group185[]"
     },
     user37: {
-        name37: "string",
+        "name37": "string",
         "friends37?": "user241[]",
-        groups37: "group127[]"
+        "groups37": "group127[]"
     },
     user38: {
-        name38: "string",
+        "name38": "string",
         "friends38?": "user175[]",
-        groups38: "group148[]"
+        "groups38": "group148[]"
     },
     user39: {
-        name39: "string",
+        "name39": "string",
         "friends39?": "user71[]",
-        groups39: "group212[]"
+        "groups39": "group212[]"
     },
     user40: {
-        name40: "string",
+        "name40": "string",
         "friends40?": "user64[]",
-        groups40: "group241[]"
+        "groups40": "group241[]"
     },
     user41: {
-        name41: "string",
+        "name41": "string",
         "friends41?": "user177[]",
-        groups41: "group185[]"
+        "groups41": "group185[]"
     },
     user42: {
-        name42: "string",
+        "name42": "string",
         "friends42?": "user97[]",
-        groups42: "group242[]"
+        "groups42": "group242[]"
     },
     user43: {
-        name43: "string",
+        "name43": "string",
         "friends43?": "user109[]",
-        groups43: "group91[]"
+        "groups43": "group91[]"
     },
     user44: {
-        name44: "string",
+        "name44": "string",
         "friends44?": "user131[]",
-        groups44: "group126[]"
+        "groups44": "group126[]"
     },
     user45: {
-        name45: "string",
+        "name45": "string",
         "friends45?": "user23[]",
-        groups45: "group10[]"
+        "groups45": "group10[]"
     },
     user46: {
-        name46: "string",
+        "name46": "string",
         "friends46?": "user9[]",
-        groups46: "group146[]"
+        "groups46": "group146[]"
     },
     user47: {
-        name47: "string",
+        "name47": "string",
         "friends47?": "user163[]",
-        groups47: "group186[]"
+        "groups47": "group186[]"
     },
     user48: {
-        name48: "string",
+        "name48": "string",
         "friends48?": "user211[]",
-        groups48: "group128[]"
+        "groups48": "group128[]"
     },
     user49: {
-        name49: "string",
+        "name49": "string",
         "friends49?": "user154[]",
-        groups49: "group149[]"
+        "groups49": "group149[]"
     },
     user50: {
-        name50: "string",
+        "name50": "string",
         "friends50?": "user67[]",
-        groups50: "group78[]"
+        "groups50": "group78[]"
     },
     user51: {
-        name51: "string",
+        "name51": "string",
         "friends51?": "user39[]",
-        groups51: "group193[]"
+        "groups51": "group193[]"
     },
     user52: {
-        name52: "string",
+        "name52": "string",
         "friends52?": "user132[]",
-        groups52: "group41[]"
+        "groups52": "group41[]"
     },
     user53: {
-        name53: "string",
+        "name53": "string",
         "friends53?": "user223[]",
-        groups53: "group58[]"
+        "groups53": "group58[]"
     },
     user54: {
-        name54: "string",
+        "name54": "string",
         "friends54?": "user228[]",
-        groups54: "group68[]"
+        "groups54": "group68[]"
     },
     user55: {
-        name55: "string",
+        "name55": "string",
         "friends55?": "user29[]",
-        groups55: "group22[]"
+        "groups55": "group22[]"
     },
     user56: {
-        name56: "string",
+        "name56": "string",
         "friends56?": "user152[]",
-        groups56: "group101[]"
+        "groups56": "group101[]"
     },
     user57: {
-        name57: "string",
+        "name57": "string",
         "friends57?": "user66[]",
-        groups57: "group138[]"
+        "groups57": "group138[]"
     },
     user58: {
-        name58: "string",
+        "name58": "string",
         "friends58?": "user60[]",
-        groups58: "group178[]"
+        "groups58": "group178[]"
     },
     user59: {
-        name59: "string",
+        "name59": "string",
         "friends59?": "user110[]",
-        groups59: "group197[]"
+        "groups59": "group197[]"
     },
     user60: {
-        name60: "string",
+        "name60": "string",
         "friends60?": "user154[]",
-        groups60: "group37[]"
+        "groups60": "group37[]"
     },
     user61: {
-        name61: "string",
+        "name61": "string",
         "friends61?": "user40[]",
-        groups61: "group11[]"
+        "groups61": "group11[]"
     },
     user62: {
-        name62: "string",
+        "name62": "string",
         "friends62?": "user227[]",
-        groups62: "group242[]"
+        "groups62": "group242[]"
     },
     user63: {
-        name63: "string",
+        "name63": "string",
         "friends63?": "user51[]",
-        groups63: "group34[]"
+        "groups63": "group34[]"
     },
     user64: {
-        name64: "string",
+        "name64": "string",
         "friends64?": "user51[]",
-        groups64: "group167[]"
+        "groups64": "group167[]"
     },
     user65: {
-        name65: "string",
+        "name65": "string",
         "friends65?": "user149[]",
-        groups65: "group16[]"
+        "groups65": "group16[]"
     },
     user66: {
-        name66: "string",
+        "name66": "string",
         "friends66?": "user178[]",
-        groups66: "group244[]"
+        "groups66": "group244[]"
     },
     user67: {
-        name67: "string",
+        "name67": "string",
         "friends67?": "user239[]",
-        groups67: "group6[]"
+        "groups67": "group6[]"
     },
     user68: {
-        name68: "string",
+        "name68": "string",
         "friends68?": "user121[]",
-        groups68: "group127[]"
+        "groups68": "group127[]"
     },
     user69: {
-        name69: "string",
+        "name69": "string",
         "friends69?": "user203[]",
-        groups69: "group156[]"
+        "groups69": "group156[]"
     },
     user70: {
-        name70: "string",
+        "name70": "string",
         "friends70?": "user144[]",
-        groups70: "group149[]"
+        "groups70": "group149[]"
     },
     user71: {
-        name71: "string",
+        "name71": "string",
         "friends71?": "user19[]",
-        groups71: "group18[]"
+        "groups71": "group18[]"
     },
     user72: {
-        name72: "string",
+        "name72": "string",
         "friends72?": "user30[]",
-        groups72: "group17[]"
+        "groups72": "group17[]"
     },
     user73: {
-        name73: "string",
+        "name73": "string",
         "friends73?": "user12[]",
-        groups73: "group116[]"
+        "groups73": "group116[]"
     },
     user74: {
-        name74: "string",
+        "name74": "string",
         "friends74?": "user93[]",
-        groups74: "group210[]"
+        "groups74": "group210[]"
     },
     user75: {
-        name75: "string",
+        "name75": "string",
         "friends75?": "user3[]",
-        groups75: "group33[]"
+        "groups75": "group33[]"
     },
     user76: {
-        name76: "string",
+        "name76": "string",
         "friends76?": "user56[]",
-        groups76: "group52[]"
+        "groups76": "group52[]"
     },
     user77: {
-        name77: "string",
+        "name77": "string",
         "friends77?": "user157[]",
-        groups77: "group239[]"
+        "groups77": "group239[]"
     },
     user78: {
-        name78: "string",
+        "name78": "string",
         "friends78?": "user147[]",
-        groups78: "group190[]"
+        "groups78": "group190[]"
     },
     user79: {
-        name79: "string",
+        "name79": "string",
         "friends79?": "user167[]",
-        groups79: "group82[]"
+        "groups79": "group82[]"
     },
     user80: {
-        name80: "string",
+        "name80": "string",
         "friends80?": "user42[]",
-        groups80: "group245[]"
+        "groups80": "group245[]"
     },
     user81: {
-        name81: "string",
+        "name81": "string",
         "friends81?": "user212[]",
-        groups81: "group67[]"
+        "groups81": "group67[]"
     },
     user82: {
-        name82: "string",
+        "name82": "string",
         "friends82?": "user124[]",
-        groups82: "group59[]"
+        "groups82": "group59[]"
     },
     user83: {
-        name83: "string",
+        "name83": "string",
         "friends83?": "user31[]",
-        groups83: "group17[]"
+        "groups83": "group17[]"
     },
     user84: {
-        name84: "string",
+        "name84": "string",
         "friends84?": "user15[]",
-        groups84: "group161[]"
+        "groups84": "group161[]"
     },
     user85: {
-        name85: "string",
+        "name85": "string",
         "friends85?": "user56[]",
-        groups85: "group208[]"
+        "groups85": "group208[]"
     },
     user86: {
-        name86: "string",
+        "name86": "string",
         "friends86?": "user205[]",
-        groups86: "group213[]"
+        "groups86": "group213[]"
     },
     user87: {
-        name87: "string",
+        "name87": "string",
         "friends87?": "user40[]",
-        groups87: "group88[]"
+        "groups87": "group88[]"
     },
     user88: {
-        name88: "string",
+        "name88": "string",
         "friends88?": "user176[]",
-        groups88: "group74[]"
+        "groups88": "group74[]"
     },
     user89: {
-        name89: "string",
+        "name89": "string",
         "friends89?": "user79[]",
-        groups89: "group132[]"
+        "groups89": "group132[]"
     },
     user90: {
-        name90: "string",
+        "name90": "string",
         "friends90?": "user4[]",
-        groups90: "group181[]"
+        "groups90": "group181[]"
     },
     user91: {
-        name91: "string",
+        "name91": "string",
         "friends91?": "user33[]",
-        groups91: "group217[]"
+        "groups91": "group217[]"
     },
     user92: {
-        name92: "string",
+        "name92": "string",
         "friends92?": "user55[]",
-        groups92: "group145[]"
+        "groups92": "group145[]"
     },
     user93: {
-        name93: "string",
+        "name93": "string",
         "friends93?": "user209[]",
-        groups93: "group53[]"
+        "groups93": "group53[]"
     },
     user94: {
-        name94: "string",
+        "name94": "string",
         "friends94?": "user215[]",
-        groups94: "group124[]"
+        "groups94": "group124[]"
     },
     user95: {
-        name95: "string",
+        "name95": "string",
         "friends95?": "user40[]",
-        groups95: "group42[]"
+        "groups95": "group42[]"
     },
     user96: {
-        name96: "string",
+        "name96": "string",
         "friends96?": "user132[]",
-        groups96: "group113[]"
+        "groups96": "group113[]"
     },
     user97: {
-        name97: "string",
+        "name97": "string",
         "friends97?": "user81[]",
-        groups97: "group173[]"
+        "groups97": "group173[]"
     },
     user98: {
-        name98: "string",
+        "name98": "string",
         "friends98?": "user34[]",
-        groups98: "group34[]"
+        "groups98": "group34[]"
     },
     user99: {
-        name99: "string",
+        "name99": "string",
         "friends99?": "user81[]",
-        groups99: "group197[]"
+        "groups99": "group197[]"
     },
     user100: {
-        name100: "string",
+        "name100": "string",
         "friends100?": "user102[]",
-        groups100: "group149[]"
+        "groups100": "group149[]"
     },
     user101: {
-        name101: "string",
+        "name101": "string",
         "friends101?": "user198[]",
-        groups101: "group81[]"
+        "groups101": "group81[]"
     },
     user102: {
-        name102: "string",
+        "name102": "string",
         "friends102?": "user206[]",
-        groups102: "group81[]"
+        "groups102": "group81[]"
     },
     user103: {
-        name103: "string",
+        "name103": "string",
         "friends103?": "user14[]",
-        groups103: "group42[]"
+        "groups103": "group42[]"
     },
     user104: {
-        name104: "string",
+        "name104": "string",
         "friends104?": "user45[]",
-        groups104: "group233[]"
+        "groups104": "group233[]"
     },
     user105: {
-        name105: "string",
+        "name105": "string",
         "friends105?": "user51[]",
-        groups105: "group8[]"
+        "groups105": "group8[]"
     },
     user106: {
-        name106: "string",
+        "name106": "string",
         "friends106?": "user103[]",
-        groups106: "group109[]"
+        "groups106": "group109[]"
     },
     user107: {
-        name107: "string",
+        "name107": "string",
         "friends107?": "user48[]",
-        groups107: "group146[]"
+        "groups107": "group146[]"
     },
     user108: {
-        name108: "string",
+        "name108": "string",
         "friends108?": "user217[]",
-        groups108: "group101[]"
+        "groups108": "group101[]"
     },
     user109: {
-        name109: "string",
+        "name109": "string",
         "friends109?": "user33[]",
-        groups109: "group142[]"
+        "groups109": "group142[]"
     },
     user110: {
-        name110: "string",
+        "name110": "string",
         "friends110?": "user204[]",
-        groups110: "group11[]"
+        "groups110": "group11[]"
     },
     user111: {
-        name111: "string",
+        "name111": "string",
         "friends111?": "user209[]",
-        groups111: "group185[]"
+        "groups111": "group185[]"
     },
     user112: {
-        name112: "string",
+        "name112": "string",
         "friends112?": "user27[]",
-        groups112: "group221[]"
+        "groups112": "group221[]"
     },
     user113: {
-        name113: "string",
+        "name113": "string",
         "friends113?": "user166[]",
-        groups113: "group154[]"
+        "groups113": "group154[]"
     },
     user114: {
-        name114: "string",
+        "name114": "string",
         "friends114?": "user239[]",
-        groups114: "group49[]"
+        "groups114": "group49[]"
     },
     user115: {
-        name115: "string",
+        "name115": "string",
         "friends115?": "user165[]",
-        groups115: "group187[]"
+        "groups115": "group187[]"
     },
     user116: {
-        name116: "string",
+        "name116": "string",
         "friends116?": "user31[]",
-        groups116: "group93[]"
+        "groups116": "group93[]"
     },
     user117: {
-        name117: "string",
+        "name117": "string",
         "friends117?": "user220[]",
-        groups117: "group210[]"
+        "groups117": "group210[]"
     },
     user118: {
-        name118: "string",
+        "name118": "string",
         "friends118?": "user34[]",
-        groups118: "group84[]"
+        "groups118": "group84[]"
     },
     user119: {
-        name119: "string",
+        "name119": "string",
         "friends119?": "user241[]",
-        groups119: "group225[]"
+        "groups119": "group225[]"
     },
     user120: {
-        name120: "string",
+        "name120": "string",
         "friends120?": "user155[]",
-        groups120: "group25[]"
+        "groups120": "group25[]"
     },
     user121: {
-        name121: "string",
+        "name121": "string",
         "friends121?": "user78[]",
-        groups121: "group132[]"
+        "groups121": "group132[]"
     },
     user122: {
-        name122: "string",
+        "name122": "string",
         "friends122?": "user8[]",
-        groups122: "group235[]"
+        "groups122": "group235[]"
     },
     user123: {
-        name123: "string",
+        "name123": "string",
         "friends123?": "user119[]",
-        groups123: "group231[]"
+        "groups123": "group231[]"
     },
     user124: {
-        name124: "string",
+        "name124": "string",
         "friends124?": "user107[]",
-        groups124: "group175[]"
+        "groups124": "group175[]"
     },
     user125: {
-        name125: "string",
+        "name125": "string",
         "friends125?": "user16[]",
-        groups125: "group172[]"
+        "groups125": "group172[]"
     },
     user126: {
-        name126: "string",
+        "name126": "string",
         "friends126?": "user88[]",
-        groups126: "group153[]"
+        "groups126": "group153[]"
     },
     user127: {
-        name127: "string",
+        "name127": "string",
         "friends127?": "user168[]",
-        groups127: "group78[]"
+        "groups127": "group78[]"
     },
     user128: {
-        name128: "string",
+        "name128": "string",
         "friends128?": "user59[]",
-        groups128: "group58[]"
+        "groups128": "group58[]"
     },
     user129: {
-        name129: "string",
+        "name129": "string",
         "friends129?": "user218[]",
-        groups129: "group178[]"
+        "groups129": "group178[]"
     },
     user130: {
-        name130: "string",
+        "name130": "string",
         "friends130?": "user47[]",
-        groups130: "group26[]"
+        "groups130": "group26[]"
     },
     user131: {
-        name131: "string",
+        "name131": "string",
         "friends131?": "user180[]",
-        groups131: "group64[]"
+        "groups131": "group64[]"
     },
     user132: {
-        name132: "string",
+        "name132": "string",
         "friends132?": "user86[]",
-        groups132: "group231[]"
+        "groups132": "group231[]"
     },
     user133: {
-        name133: "string",
+        "name133": "string",
         "friends133?": "user189[]",
-        groups133: "group95[]"
+        "groups133": "group95[]"
     },
     user134: {
-        name134: "string",
+        "name134": "string",
         "friends134?": "user58[]",
-        groups134: "group13[]"
+        "groups134": "group13[]"
     },
     user135: {
-        name135: "string",
+        "name135": "string",
         "friends135?": "user151[]",
-        groups135: "group49[]"
+        "groups135": "group49[]"
     },
     user136: {
-        name136: "string",
+        "name136": "string",
         "friends136?": "user31[]",
-        groups136: "group186[]"
+        "groups136": "group186[]"
     },
     user137: {
-        name137: "string",
+        "name137": "string",
         "friends137?": "user164[]",
-        groups137: "group147[]"
+        "groups137": "group147[]"
     },
     user138: {
-        name138: "string",
+        "name138": "string",
         "friends138?": "user234[]",
-        groups138: "group16[]"
+        "groups138": "group16[]"
     },
     user139: {
-        name139: "string",
+        "name139": "string",
         "friends139?": "user237[]",
-        groups139: "group242[]"
+        "groups139": "group242[]"
     },
     user140: {
-        name140: "string",
+        "name140": "string",
         "friends140?": "user44[]",
-        groups140: "group62[]"
+        "groups140": "group62[]"
     },
     user141: {
-        name141: "string",
+        "name141": "string",
         "friends141?": "user219[]",
-        groups141: "group106[]"
+        "groups141": "group106[]"
     },
     user142: {
-        name142: "string",
+        "name142": "string",
         "friends142?": "user192[]",
-        groups142: "group47[]"
+        "groups142": "group47[]"
     },
     user143: {
-        name143: "string",
+        "name143": "string",
         "friends143?": "user103[]",
-        groups143: "group106[]"
+        "groups143": "group106[]"
     },
     user144: {
-        name144: "string",
+        "name144": "string",
         "friends144?": "user198[]",
-        groups144: "group37[]"
+        "groups144": "group37[]"
     },
     user145: {
-        name145: "string",
+        "name145": "string",
         "friends145?": "user168[]",
-        groups145: "group71[]"
+        "groups145": "group71[]"
     },
     user146: {
-        name146: "string",
+        "name146": "string",
         "friends146?": "user18[]",
-        groups146: "group79[]"
+        "groups146": "group79[]"
     },
     user147: {
-        name147: "string",
+        "name147": "string",
         "friends147?": "user190[]",
-        groups147: "group93[]"
+        "groups147": "group93[]"
     },
     user148: {
-        name148: "string",
+        "name148": "string",
         "friends148?": "user141[]",
-        groups148: "group110[]"
+        "groups148": "group110[]"
     },
     user149: {
-        name149: "string",
+        "name149": "string",
         "friends149?": "user80[]",
-        groups149: "group249[]"
+        "groups149": "group249[]"
     },
     user150: {
-        name150: "string",
+        "name150": "string",
         "friends150?": "user98[]",
-        groups150: "group145[]"
+        "groups150": "group145[]"
     },
     user151: {
-        name151: "string",
+        "name151": "string",
         "friends151?": "user180[]",
-        groups151: "group39[]"
+        "groups151": "group39[]"
     },
     user152: {
-        name152: "string",
+        "name152": "string",
         "friends152?": "user208[]",
-        groups152: "group68[]"
+        "groups152": "group68[]"
     },
     user153: {
-        name153: "string",
+        "name153": "string",
         "friends153?": "user51[]",
-        groups153: "group42[]"
+        "groups153": "group42[]"
     },
     user154: {
-        name154: "string",
+        "name154": "string",
         "friends154?": "user66[]",
-        groups154: "group229[]"
+        "groups154": "group229[]"
     },
     user155: {
-        name155: "string",
+        "name155": "string",
         "friends155?": "user211[]",
-        groups155: "group42[]"
+        "groups155": "group42[]"
     },
     user156: {
-        name156: "string",
+        "name156": "string",
         "friends156?": "user187[]",
-        groups156: "group125[]"
+        "groups156": "group125[]"
     },
     user157: {
-        name157: "string",
+        "name157": "string",
         "friends157?": "user234[]",
-        groups157: "group81[]"
+        "groups157": "group81[]"
     },
     user158: {
-        name158: "string",
+        "name158": "string",
         "friends158?": "user88[]",
-        groups158: "group33[]"
+        "groups158": "group33[]"
     },
     user159: {
-        name159: "string",
+        "name159": "string",
         "friends159?": "user35[]",
-        groups159: "group188[]"
+        "groups159": "group188[]"
     },
     user160: {
-        name160: "string",
+        "name160": "string",
         "friends160?": "user135[]",
-        groups160: "group207[]"
+        "groups160": "group207[]"
     },
     user161: {
-        name161: "string",
+        "name161": "string",
         "friends161?": "user145[]",
-        groups161: "group240[]"
+        "groups161": "group240[]"
     },
     user162: {
-        name162: "string",
+        "name162": "string",
         "friends162?": "user15[]",
-        groups162: "group7[]"
+        "groups162": "group7[]"
     },
     user163: {
-        name163: "string",
+        "name163": "string",
         "friends163?": "user113[]",
-        groups163: "group67[]"
+        "groups163": "group67[]"
     },
     user164: {
-        name164: "string",
+        "name164": "string",
         "friends164?": "user6[]",
-        groups164: "group197[]"
+        "groups164": "group197[]"
     },
     user165: {
-        name165: "string",
+        "name165": "string",
         "friends165?": "user174[]",
-        groups165: "group220[]"
+        "groups165": "group220[]"
     },
     user166: {
-        name166: "string",
+        "name166": "string",
         "friends166?": "user98[]",
-        groups166: "group74[]"
+        "groups166": "group74[]"
     },
     user167: {
-        name167: "string",
+        "name167": "string",
         "friends167?": "user203[]",
-        groups167: "group89[]"
+        "groups167": "group89[]"
     },
     user168: {
-        name168: "string",
+        "name168": "string",
         "friends168?": "user42[]",
-        groups168: "group246[]"
+        "groups168": "group246[]"
     },
     user169: {
-        name169: "string",
+        "name169": "string",
         "friends169?": "user36[]",
-        groups169: "group7[]"
+        "groups169": "group7[]"
     },
     user170: {
-        name170: "string",
+        "name170": "string",
         "friends170?": "user89[]",
-        groups170: "group234[]"
+        "groups170": "group234[]"
     },
     user171: {
-        name171: "string",
+        "name171": "string",
         "friends171?": "user245[]",
-        groups171: "group105[]"
+        "groups171": "group105[]"
     },
     user172: {
-        name172: "string",
+        "name172": "string",
         "friends172?": "user130[]",
-        groups172: "group219[]"
+        "groups172": "group219[]"
     },
     user173: {
-        name173: "string",
+        "name173": "string",
         "friends173?": "user194[]",
-        groups173: "group59[]"
+        "groups173": "group59[]"
     },
     user174: {
-        name174: "string",
+        "name174": "string",
         "friends174?": "user95[]",
-        groups174: "group109[]"
+        "groups174": "group109[]"
     },
     user175: {
-        name175: "string",
+        "name175": "string",
         "friends175?": "user241[]",
-        groups175: "group155[]"
+        "groups175": "group155[]"
     },
     user176: {
-        name176: "string",
+        "name176": "string",
         "friends176?": "user139[]",
-        groups176: "group136[]"
+        "groups176": "group136[]"
     },
     user177: {
-        name177: "string",
+        "name177": "string",
         "friends177?": "user166[]",
-        groups177: "group34[]"
+        "groups177": "group34[]"
     },
     user178: {
-        name178: "string",
+        "name178": "string",
         "friends178?": "user159[]",
-        groups178: "group94[]"
+        "groups178": "group94[]"
     },
     user179: {
-        name179: "string",
+        "name179": "string",
         "friends179?": "user68[]",
-        groups179: "group56[]"
+        "groups179": "group56[]"
     },
     user180: {
-        name180: "string",
+        "name180": "string",
         "friends180?": "user30[]",
-        groups180: "group235[]"
+        "groups180": "group235[]"
     },
     user181: {
-        name181: "string",
+        "name181": "string",
         "friends181?": "user69[]",
-        groups181: "group84[]"
+        "groups181": "group84[]"
     },
     user182: {
-        name182: "string",
+        "name182": "string",
         "friends182?": "user131[]",
-        groups182: "group158[]"
+        "groups182": "group158[]"
     },
     user183: {
-        name183: "string",
+        "name183": "string",
         "friends183?": "user124[]",
-        groups183: "group192[]"
+        "groups183": "group192[]"
     },
     user184: {
-        name184: "string",
+        "name184": "string",
         "friends184?": "user175[]",
-        groups184: "group87[]"
+        "groups184": "group87[]"
     },
     user185: {
-        name185: "string",
+        "name185": "string",
         "friends185?": "user250[]",
-        groups185: "group130[]"
+        "groups185": "group130[]"
     },
     user186: {
-        name186: "string",
+        "name186": "string",
         "friends186?": "user97[]",
-        groups186: "group207[]"
+        "groups186": "group207[]"
     },
     user187: {
-        name187: "string",
+        "name187": "string",
         "friends187?": "user102[]",
-        groups187: "group141[]"
+        "groups187": "group141[]"
     },
     user188: {
-        name188: "string",
+        "name188": "string",
         "friends188?": "user248[]",
-        groups188: "group158[]"
+        "groups188": "group158[]"
     },
     user189: {
-        name189: "string",
+        "name189": "string",
         "friends189?": "user191[]",
-        groups189: "group12[]"
+        "groups189": "group12[]"
     },
     user190: {
-        name190: "string",
+        "name190": "string",
         "friends190?": "user164[]",
-        groups190: "group137[]"
+        "groups190": "group137[]"
     },
     user191: {
-        name191: "string",
+        "name191": "string",
         "friends191?": "user128[]",
-        groups191: "group138[]"
+        "groups191": "group138[]"
     },
     user192: {
-        name192: "string",
+        "name192": "string",
         "friends192?": "user130[]",
-        groups192: "group185[]"
+        "groups192": "group185[]"
     },
     user193: {
-        name193: "string",
+        "name193": "string",
         "friends193?": "user110[]",
-        groups193: "group195[]"
+        "groups193": "group195[]"
     },
     user194: {
-        name194: "string",
+        "name194": "string",
         "friends194?": "user12[]",
-        groups194: "group76[]"
+        "groups194": "group76[]"
     },
     user195: {
-        name195: "string",
+        "name195": "string",
         "friends195?": "user89[]",
-        groups195: "group46[]"
+        "groups195": "group46[]"
     },
     user196: {
-        name196: "string",
+        "name196": "string",
         "friends196?": "user186[]",
-        groups196: "group16[]"
+        "groups196": "group16[]"
     },
     user197: {
-        name197: "string",
+        "name197": "string",
         "friends197?": "user246[]",
-        groups197: "group154[]"
+        "groups197": "group154[]"
     },
     user198: {
-        name198: "string",
+        "name198": "string",
         "friends198?": "user207[]",
-        groups198: "group51[]"
+        "groups198": "group51[]"
     },
     user199: {
-        name199: "string",
+        "name199": "string",
         "friends199?": "user220[]",
-        groups199: "group132[]"
+        "groups199": "group132[]"
     },
     user200: {
-        name200: "string",
+        "name200": "string",
         "friends200?": "user177[]",
-        groups200: "group109[]"
+        "groups200": "group109[]"
     },
     user201: {
-        name201: "string",
+        "name201": "string",
         "friends201?": "user246[]",
-        groups201: "group236[]"
+        "groups201": "group236[]"
     },
     user202: {
-        name202: "string",
+        "name202": "string",
         "friends202?": "user202[]",
-        groups202: "group127[]"
+        "groups202": "group127[]"
     },
     user203: {
-        name203: "string",
+        "name203": "string",
         "friends203?": "user18[]",
-        groups203: "group122[]"
+        "groups203": "group122[]"
     },
     user204: {
-        name204: "string",
+        "name204": "string",
         "friends204?": "user132[]",
-        groups204: "group208[]"
+        "groups204": "group208[]"
     },
     user205: {
-        name205: "string",
+        "name205": "string",
         "friends205?": "user132[]",
-        groups205: "group92[]"
+        "groups205": "group92[]"
     },
     user206: {
-        name206: "string",
+        "name206": "string",
         "friends206?": "user229[]",
-        groups206: "group118[]"
+        "groups206": "group118[]"
     },
     user207: {
-        name207: "string",
+        "name207": "string",
         "friends207?": "user171[]",
-        groups207: "group235[]"
+        "groups207": "group235[]"
     },
     user208: {
-        name208: "string",
+        "name208": "string",
         "friends208?": "user36[]",
-        groups208: "group8[]"
+        "groups208": "group8[]"
     },
     user209: {
-        name209: "string",
+        "name209": "string",
         "friends209?": "user122[]",
-        groups209: "group15[]"
+        "groups209": "group15[]"
     },
     user210: {
-        name210: "string",
+        "name210": "string",
         "friends210?": "user231[]",
-        groups210: "group145[]"
+        "groups210": "group145[]"
     },
     user211: {
-        name211: "string",
+        "name211": "string",
         "friends211?": "user127[]",
-        groups211: "group149[]"
+        "groups211": "group149[]"
     },
     user212: {
-        name212: "string",
+        "name212": "string",
         "friends212?": "user189[]",
-        groups212: "group147[]"
+        "groups212": "group147[]"
     },
     user213: {
-        name213: "string",
+        "name213": "string",
         "friends213?": "user238[]",
-        groups213: "group88[]"
+        "groups213": "group88[]"
     },
     user214: {
-        name214: "string",
+        "name214": "string",
         "friends214?": "user239[]",
-        groups214: "group169[]"
+        "groups214": "group169[]"
     },
     user215: {
-        name215: "string",
+        "name215": "string",
         "friends215?": "user109[]",
-        groups215: "group245[]"
+        "groups215": "group245[]"
     },
     user216: {
-        name216: "string",
+        "name216": "string",
         "friends216?": "user78[]",
-        groups216: "group225[]"
+        "groups216": "group225[]"
     },
     user217: {
-        name217: "string",
+        "name217": "string",
         "friends217?": "user197[]",
-        groups217: "group120[]"
+        "groups217": "group120[]"
     },
     user218: {
-        name218: "string",
+        "name218": "string",
         "friends218?": "user186[]",
-        groups218: "group99[]"
+        "groups218": "group99[]"
     },
     user219: {
-        name219: "string",
+        "name219": "string",
         "friends219?": "user33[]",
-        groups219: "group222[]"
+        "groups219": "group222[]"
     },
     user220: {
-        name220: "string",
+        "name220": "string",
         "friends220?": "user90[]",
-        groups220: "group114[]"
+        "groups220": "group114[]"
     },
     user221: {
-        name221: "string",
+        "name221": "string",
         "friends221?": "user134[]",
-        groups221: "group35[]"
+        "groups221": "group35[]"
     },
     user222: {
-        name222: "string",
+        "name222": "string",
         "friends222?": "user225[]",
-        groups222: "group178[]"
+        "groups222": "group178[]"
     },
     user223: {
-        name223: "string",
+        "name223": "string",
         "friends223?": "user215[]",
-        groups223: "group93[]"
+        "groups223": "group93[]"
     },
     user224: {
-        name224: "string",
+        "name224": "string",
         "friends224?": "user19[]",
-        groups224: "group174[]"
+        "groups224": "group174[]"
     },
     user225: {
-        name225: "string",
+        "name225": "string",
         "friends225?": "user223[]",
-        groups225: "group127[]"
+        "groups225": "group127[]"
     },
     user226: {
-        name226: "string",
+        "name226": "string",
         "friends226?": "user20[]",
-        groups226: "group210[]"
+        "groups226": "group210[]"
     },
     user227: {
-        name227: "string",
+        "name227": "string",
         "friends227?": "user208[]",
-        groups227: "group177[]"
+        "groups227": "group177[]"
     },
     user228: {
-        name228: "string",
+        "name228": "string",
         "friends228?": "user109[]",
-        groups228: "group139[]"
+        "groups228": "group139[]"
     },
     user229: {
-        name229: "string",
+        "name229": "string",
         "friends229?": "user30[]",
-        groups229: "group140[]"
+        "groups229": "group140[]"
     },
     user230: {
-        name230: "string",
+        "name230": "string",
         "friends230?": "user85[]",
-        groups230: "group188[]"
+        "groups230": "group188[]"
     },
     user231: {
-        name231: "string",
+        "name231": "string",
         "friends231?": "user200[]",
-        groups231: "group108[]"
+        "groups231": "group108[]"
     },
     user232: {
-        name232: "string",
+        "name232": "string",
         "friends232?": "user20[]",
-        groups232: "group46[]"
+        "groups232": "group46[]"
     },
     user233: {
-        name233: "string",
+        "name233": "string",
         "friends233?": "user98[]",
-        groups233: "group121[]"
+        "groups233": "group121[]"
     },
     user234: {
-        name234: "string",
+        "name234": "string",
         "friends234?": "user117[]",
-        groups234: "group166[]"
+        "groups234": "group166[]"
     },
     user235: {
-        name235: "string",
+        "name235": "string",
         "friends235?": "user90[]",
-        groups235: "group84[]"
+        "groups235": "group84[]"
     },
     user236: {
-        name236: "string",
+        "name236": "string",
         "friends236?": "user175[]",
-        groups236: "group162[]"
+        "groups236": "group162[]"
     },
     user237: {
-        name237: "string",
+        "name237": "string",
         "friends237?": "user233[]",
-        groups237: "group20[]"
+        "groups237": "group20[]"
     },
     user238: {
-        name238: "string",
+        "name238": "string",
         "friends238?": "user175[]",
-        groups238: "group48[]"
+        "groups238": "group48[]"
     },
     user239: {
-        name239: "string",
+        "name239": "string",
         "friends239?": "user4[]",
-        groups239: "group71[]"
+        "groups239": "group71[]"
     },
     user240: {
-        name240: "string",
+        "name240": "string",
         "friends240?": "user32[]",
-        groups240: "group159[]"
+        "groups240": "group159[]"
     },
     user241: {
-        name241: "string",
+        "name241": "string",
         "friends241?": "user175[]",
-        groups241: "group173[]"
+        "groups241": "group173[]"
     },
     user242: {
-        name242: "string",
+        "name242": "string",
         "friends242?": "user162[]",
-        groups242: "group37[]"
+        "groups242": "group37[]"
     },
     user243: {
-        name243: "string",
+        "name243": "string",
         "friends243?": "user246[]",
-        groups243: "group168[]"
+        "groups243": "group168[]"
     },
     user244: {
-        name244: "string",
+        "name244": "string",
         "friends244?": "user202[]",
-        groups244: "group91[]"
+        "groups244": "group91[]"
     },
     user245: {
-        name245: "string",
+        "name245": "string",
         "friends245?": "user19[]",
-        groups245: "group234[]"
+        "groups245": "group234[]"
     },
     user246: {
-        name246: "string",
+        "name246": "string",
         "friends246?": "user82[]",
-        groups246: "group129[]"
+        "groups246": "group129[]"
     },
     user247: {
-        name247: "string",
+        "name247": "string",
         "friends247?": "user102[]",
-        groups247: "group86[]"
+        "groups247": "group86[]"
     },
     user248: {
-        name248: "string",
+        "name248": "string",
         "friends248?": "user18[]",
-        groups248: "group235[]"
+        "groups248": "group235[]"
     },
     user249: {
-        name249: "string",
+        "name249": "string",
         "friends249?": "user202[]",
-        groups249: "group238[]"
+        "groups249": "group238[]"
     },
     user250: {
-        name250: "string",
+        "name250": "string",
         "friends250?": "user151[]",
-        groups250: "group71[]"
+        "groups250": "group71[]"
     },
     group: {
         title: "string",

--- a/dev/test/intersection.test.ts
+++ b/dev/test/intersection.test.ts
@@ -89,7 +89,7 @@ describe("intersection", () => {
                         "0": {
                             object: { props: { a: "string", b: "boolean" } }
                         },
-                        length: ["!", { number: { value: 1 } }]
+                        "length": ["!", { number: { value: 1 } }]
                     }
                 }
             })
@@ -124,7 +124,7 @@ describe("intersection", () => {
                         "0": {
                             object: { props: { a: "string", b: "boolean" } }
                         },
-                        length: ["!", { number: { value: 1 } }]
+                        "length": ["!", { number: { value: 1 } }]
                     }
                 }
             }
@@ -149,7 +149,7 @@ describe("intersection", () => {
                     props: {
                         "0": "alpha",
                         "1": "alpha",
-                        length: ["!", { number: { value: 2 } }]
+                        "length": ["!", { number: { value: 2 } }]
                     }
                 }
             })
@@ -165,7 +165,7 @@ describe("intersection", () => {
                     props: {
                         "0": { number: { value: 1 } },
                         "1": { string: { value: "one" } },
-                        length: ["!", { number: { value: 2 } }]
+                        "length": ["!", { number: { value: 2 } }]
                     }
                 }
             })

--- a/dev/test/morph.test.ts
+++ b/dev/test/morph.test.ts
@@ -249,7 +249,7 @@ describe("morph", () => {
                         class: `(function Array)`,
                         props: {
                             "0": "string",
-                            length: ["!", { number: { value: 1 } }]
+                            "length": ["!", { number: { value: 1 } }]
                         }
                     },
                     morph: "(function)"
@@ -258,7 +258,7 @@ describe("morph", () => {
                     class: `(function Array)`,
                     props: {
                         "0": "boolean",
-                        length: ["!", { number: { value: 1 } }]
+                        "length": ["!", { number: { value: 1 } }]
                     }
                 }
             ]

--- a/dev/test/nodeDefinitions.test.ts
+++ b/dev/test/nodeDefinitions.test.ts
@@ -72,7 +72,7 @@ describe("node definitions", () => {
                     class: Array,
                     props: {
                         "[index]": "string",
-                        length: { number: { value: 5 } }
+                        "length": { number: { value: 5 } }
                     }
                 }
             } as const

--- a/dev/test/record.test.ts
+++ b/dev/test/record.test.ts
@@ -21,7 +21,7 @@ describe("record", () => {
         })
     })
     it("optional keys", () => {
-        const o = type({ "a?": "string", b: "boolean[]" })
+        const o = type({ "a?": "string", "b": "boolean[]" })
         attest(o.infer).typed as { a?: string; b: boolean[] }
         attest(o.node).snap({
             object: {

--- a/dev/test/traverse.test.ts
+++ b/dev/test/traverse.test.ts
@@ -27,8 +27,8 @@ describe("traverse", () => {
     })
     it("required keys", () => {
         const t = type({
-            name: "string",
-            age: "number",
+            "name": "string",
+            "age": "number",
             "title?": "string"
         })
         attest(t({ name: "Shawn", age: 99 }).data).snap({

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "prettier": {
         "tabWidth": 4,
         "semi": false,
+        "quoteProps": "consistent",
         "trailingComma": "none"
     },
     "mocha": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "files": [
         "dist"
     ],
-    "packageManager": "pnpm@7.27.0",
+    "packageManager": "pnpm@7.32.2",
     "scripts": {
         "prChecks": "pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm testRepo && pnpm docgen && pnpm buildSite",
         "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ],
     "packageManager": "pnpm@8.3.1",
     "scripts": {
-        "prChecks": "pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm testRepo && pnpm docgen && pnpm buildSite",
+        "prChecks": "pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm format && pnpm testRepo && pnpm docgen && pnpm buildSite",
         "typecheck": "tsc --noEmit",
         "build": "ts-node ./dev/scripts/build.ts",
         "buildRepo": "pnpm build && pnpm docgen && pnpm buildSite",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "files": [
         "dist"
     ],
-    "packageManager": "pnpm@7.32.2",
+    "packageManager": "pnpm@8.3.1",
     "scripts": {
         "prChecks": "pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm testRepo && pnpm docgen && pnpm buildSite",
         "typecheck": "tsc --noEmit",

--- a/src/parse/ast/node.ts
+++ b/src/parse/ast/node.ts
@@ -76,7 +76,7 @@ type inferObjectRules<
 > = rules["class"] extends ArrayConstructor
     ? rules["props"] extends {
           "[index]": Prop<$, infer indexNode>
-          length?: Prop<$, infer lengthNode>
+          "length"?: Prop<$, infer lengthNode>
       }
         ? lengthNode extends LiteralNode<"number", infer value>
             ? HomogenousTuple<inferNode<indexNode, $>, value>

--- a/src/parse/ast/tuple.ts
+++ b/src/parse/ast/tuple.ts
@@ -90,8 +90,8 @@ export type validateTupleExpression<
     : never
 
 export type UnparsedTupleExpressionInput<$> = {
-    instanceof: constructor
-    node: ResolvedNode<$>
+    "instanceof": constructor
+    "node": ResolvedNode<$>
     "===": unknown
 }
 
@@ -203,8 +203,8 @@ export type IndexZeroExpression<
 const prefixParsers: {
     [token in IndexZeroOperator]: PrefixParser<token>
 } = {
-    keyof: parseKeyOfTuple,
-    instanceof: (def) => {
+    "keyof": parseKeyOfTuple,
+    "instanceof": (def) => {
         if (typeof def[1] !== "function") {
             return throwParseError(
                 `Expected a constructor following 'instanceof' operator (was ${typeof def[1]}).`
@@ -213,7 +213,7 @@ const prefixParsers: {
         return { object: { class: def[1] as constructor } }
     },
     "===": (def) => ({ [domainOf(def[1])]: { value: def[1] } }),
-    node: (def) => def[1] as ResolvedNode
+    "node": (def) => def[1] as ResolvedNode
 }
 
 const isIndexZeroExpression = (def: List): def is IndexZeroExpression =>

--- a/src/parse/string/reduce/static.ts
+++ b/src/parse/string/reduce/static.ts
@@ -24,7 +24,7 @@ export type StaticState = {
 type StaticOpenLeftBound = { limit: NumberLiteral; comparator: MinComparator }
 
 type BranchState = {
-    range: StaticOpenLeftBound | undefined
+    "range": StaticOpenLeftBound | undefined
     "&": unknown
     "|": unknown
 }
@@ -39,7 +39,7 @@ export namespace state {
     }>
 
     type initialBranches = branchesFrom<{
-        range: undefined
+        "range": undefined
         "&": undefined
         "|": undefined
     }>
@@ -73,7 +73,7 @@ export namespace state {
         : from<{
               root: undefined
               branches: {
-                  range: undefined
+                  "range": undefined
                   "&": token extends "&" ? mergeToIntersection<s> : undefined
                   "|": token extends "|" ? mergeToUnion<s> : s["branches"]["|"]
               }
@@ -100,7 +100,7 @@ export namespace state {
             : from<{
                   root: undefined
                   branches: {
-                      range: {
+                      "range": {
                           limit: limit
                           comparator: Scanner.InvertedComparators[comparator]
                       }
@@ -127,7 +127,7 @@ export namespace state {
     > = state.from<{
         root: [minLimit, minComparator, [s["root"], maxComparator, maxLimit]]
         branches: {
-            range: undefined
+            "range": undefined
             "&": s["branches"]["&"]
             "|": s["branches"]["|"]
         }
@@ -144,7 +144,7 @@ export namespace state {
     > = state.from<{
         root: [s["root"], comparator, limit]
         branches: {
-            range: undefined
+            "range": undefined
             "&": s["branches"]["&"]
             "|": s["branches"]["|"]
         }


### PR DESCRIPTION
**Depends on #725**

When using ArkType, users will frequently add characters like `?` that need to be quoted, so we should quote props consistently when they are used.