### PR TITLE
feat: only allow safe-precision integers to pass `parsedInteger`

### DIFF
--- a/dev/test/keywords.test.ts
+++ b/dev/test/keywords.test.ts
@@ -156,6 +156,9 @@ describe("keywords", () => {
             attest(parsedInteger("5.5").problems?.summary).snap(
                 "Must be a well-formed integer string (was '5.5')"
             )
+            attest(parsedInteger("five").problems?.summary).snap(
+                "Must be a well-formed integer string (was 'five')"
+            )
             attest(parsedInteger(5).problems?.summary).snap(
                 "Must be a string (was number)"
             )

--- a/dev/test/keywords.test.ts
+++ b/dev/test/keywords.test.ts
@@ -157,7 +157,10 @@ describe("keywords", () => {
                 "Must be a well-formed integer string (was '5.5')"
             )
             attest(parsedInteger(5).problems?.summary).snap(
-                "Must be a well-formed integer string (was number)"
+                "Must be a string (was number)"
+            )
+            attest(parsedInteger("9007199254740992").problems?.summary).snap(
+                "Must be an integer in the range Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER (was '9007199254740992')"
             )
         })
         it("parsedDate", () => {

--- a/src/scopes/validation/validation.ts
+++ b/src/scopes/validation/validation.ts
@@ -1,5 +1,5 @@
 import {
-    wellFormedIntegerMatcher,
+    isWellFormedInteger,
     wellFormedNumberMatcher
 } from "../../utils/numericLiterals.js"
 import { rootType, scope } from "../scope.js"
@@ -14,10 +14,23 @@ const parsedNumber = rootType(
     { mustBe: "a well-formed numeric string" }
 )
 
-const parsedInteger = rootType(
-    [wellFormedIntegerMatcher, "|>", (s) => parseInt(s)],
-    { mustBe: "a well-formed integer string" }
-)
+const parsedInteger = rootType([
+    tsKeywords.string,
+    "|>",
+    (s, problems) => {
+        if (!isWellFormedInteger(s)) {
+            return problems.mustBe("a well-formed integer string")
+        }
+
+        const parsed = parseInt(s)
+
+        return Number.isSafeInteger(parsed)
+            ? parsed
+            : problems.mustBe(
+                  "an integer in the range Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER"
+              )
+    }
+])
 
 // https://www.regular-expressions.info/email.html
 const email = rootType(/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/, {


### PR DESCRIPTION
Fixes #743

This commit adds an additional check to the `parsedInteger` validator, using `Number.isSafeInteger()` to require that any parsed integer has maximum precision (cannot overflow). This better represents what the average user would want, but may fail on some valid inputs. An `unsafeParsedInteger` validator should be considered in the future.

Due to many upcoming changes to error scopes, 'string' was used as the base type and the regex check was made in the narrow. The error message when a non-string is passed has changed slightly, just saying "must be a string" instead of "must be a well-formed integer string." This is a very minor change and can be dismissed.

BREAKING CHANGE: Any unsafe integers that use the `parsedInteger` validator will now fail the validation.
