### PR TITLE
Make types keep JSDoc for required keys

### DIFF
--- a/dev/test/jsdoc.test.ts
+++ b/dev/test/jsdoc.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "mocha"
+import { scope, type } from "../../src/main.js"
+
+const ab = { a: "1", b: 1 }
+describe("= JSDoc =", () => {
+    // Note: `<#` are not checked, they are for understandability
+    it("objects keep JSDoc", () => {
+        type({
+            /** JSDoc */
+            a: "string"
+        }).assert(ab).a // <# JSDoc
+    })
+    it("intersections keep JSDoc", () => {
+        type([
+            {
+                /** JSDoc */
+                a: "string"
+            },
+            "&",
+            {
+                b: "number"
+            }
+        ]).assert(ab).a // <# JSDoc
+
+        type([
+            {
+                /** First */
+                a: "string"
+            },
+            "&",
+            {
+                /** Second */
+                a: "string"
+            }
+        ]).assert(ab).a // <# First
+
+        scope({
+            a: {
+                /** JSDoc */
+                a: "string"
+            },
+            b: {
+                b: "number"
+            },
+            ab: "a & b"
+        })
+            .compile()
+            .ab.assert(ab).a // <# JSDoc
+    })
+
+    it("works with module scopes", () => {
+        scope({
+            /** JSDoc */
+            a: "string"
+        }).compile().a // <# JSDoc
+    })
+
+    it("doesn't work with optional keys", () => {
+        type({
+            /** JSDoc */
+            "a?": "string"
+        }).assert(ab).a // <# ---
+    })
+})

--- a/src/parse/ast/intersection.ts
+++ b/src/parse/ast/intersection.ts
@@ -9,7 +9,6 @@ import type {
     extractValues,
     isAny,
     List,
-    stringKeyOf,
     tryCatch
 } from "../../utils/generics.js"
 import { objectKeysOf } from "../../utils/generics.js"
@@ -42,7 +41,9 @@ type inferIntersectionRecurse<
     ? bubblePropErrors<
           evaluate<
               {
-                  [k in stringKeyOf<l>]: k extends keyof r
+                  [k in keyof l as k extends string
+                      ? k
+                      : never]: k extends keyof r
                       ? inferIntersectionRecurse<l[k], r[k], [...path, k]>
                       : l[k]
               } & Omit<r, keyof l>

--- a/src/parse/ast/union.ts
+++ b/src/parse/ast/union.ts
@@ -5,6 +5,7 @@ import type {
     error,
     extractValues,
     isAny,
+    optionalKeyOf,
     requiredKeyOf
 } from "../../utils/generics.js"
 import type { objectKindOf } from "../../utils/objectKinds.js"
@@ -42,8 +43,14 @@ type discriminatableRecurse<
     : [objectKindOf<l>, objectKindOf<r>] extends ["Object", "Object"]
     ? extractValues<
           {
-              [k in requiredKeyOf<l>]: k extends requiredKeyOf<r>
-                  ? discriminatableRecurse<l[k], r[k], [...path, k & string]>
+              [k in keyof l as k extends optionalKeyOf<l>
+                  ? never
+                  : k]: k extends requiredKeyOf<r>
+                  ? discriminatableRecurse<
+                        l[k],
+                        r[k],
+                        [...path, k & string]
+                    > & { _: l }
                   : never
           },
           string[]

--- a/src/parse/record.ts
+++ b/src/parse/record.ts
@@ -39,7 +39,9 @@ type withPossiblePreviousEscapeCharacter<k> = k extends `${infer name}?`
 
 export type inferRecord<def extends Dict, $> = evaluate<
     {
-        [requiredKeyName in requiredKeyOf<def>]: inferDefinition<
+        [requiredKeyName in keyof def as requiredKeyName extends optionalKeyOf<def>
+            ? never
+            : requiredKeyName]: inferDefinition<
             def[withPossiblePreviousEscapeCharacter<requiredKeyName>],
             $
         >
@@ -70,11 +72,4 @@ type optionalKeyOf<def> = {
         : never
 }[keyof def] &
     // ensure keyof is fully evaluated for inferred types
-    unknown
-
-type requiredKeyOf<def> = {
-    [k in keyof def]: parseKey<k> extends KeyParseResult<infer name, false>
-        ? name
-        : never
-}[keyof def] &
     unknown


### PR DESCRIPTION
This PR makes JSDoc comments in definition to persist into the inferred type

```ts
type({
    /** JSDoc */
    a: "string"
}).assert(ab).a // <# JSDoc
```

This also makes the keys to have jump-to-definition to the definition where they came from

This is limited to required keys only, as optional keys definition differ from the key itself