### PR TITLE
feat: improve highlighting for python, yml, and ruby

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,4 +1,6 @@
 titleOnly: true
 scopes:
   - attest
+  - arkdark
+  - arktype
   - arktype.io

--- a/ark/dark/color-theme.json
+++ b/ark/dark/color-theme.json
@@ -4,14 +4,42 @@
 	"tokenColors": [
 		{
 			"name": "functions",
-			"scope": ["entity.name.function"],
+			"scope": ["entity.name.function", "meta.function-call", "support.function"],
 			"settings": {
 				"foreground": "#80cff8"
 			}
 		},
 		{
-			"name": "types",
-			"scope": ["entity.name.type"],
+			"name": "function arguments",
+			"scope": ["meta.function-call.arguments"],
+			"settings": {
+				"foreground": "#eeeeee"
+			}
+		},
+		{
+			"name": "escapes",
+			"scope": ["constant.character.escape"],
+			"settings": {
+				"foreground": "#eb9f2e",
+			}
+		},
+		{
+			"name": "tags",
+			"scope": ["entity.name.tag"],
+			"settings": {
+				"foreground": "#408fde",
+			}
+		},
+		{
+			"name": "decorators",
+			"scope": ["punctuation.definition.decorator"],
+			"settings": {
+				"foreground": "#80cff8",
+			}
+		},
+		{
+			"name": "types and exceptions",
+			"scope": ["entity.name.type", "support.type.exception"],
 			"settings": {
 				"foreground": "#40decc"
 			}


### PR DESCRIPTION
Adds some extra scopes and highlight rules, as follows:

- `meta.function-call` and `support.function`
  - This adds function highlighting for Python and Ruby, respectively
- `meta.function-call.arguments`
  - Prevents function arguments getting highlighting as functions in Python
- `constant.character.escape`
  - Highlight escape sequences in Python, such as `\n`, `\t`, etc.
- `entity.name.tag`
  - Better highlighting for `.yml` file keys
- `support.type.exception`
  - Highlighting exceptions in Python as a type
  
I haven't extensively tested this, but the above does seem to be working correctly and I haven't noticed any side-effects in ts/js files in my limited experimenting.

Some examples:

Before
<img width="448" alt="yml key before" src="https://github.com/arktypeio/arktype/assets/47674925/5ad06125-0515-4dc7-98c3-f2369f09b5f9">
<img width="852" alt="function and exception before" src="https://github.com/arktypeio/arktype/assets/47674925/84888c45-073e-42a6-b7eb-1334a082a41c">
<img width="325" alt="decorator before" src="https://github.com/arktypeio/arktype/assets/47674925/f4affb01-a9d4-49df-80a5-e8e50df7130d">



After
<img width="456" alt="yml key after" src="https://github.com/arktypeio/arktype/assets/47674925/9699304e-38ee-4098-9d4e-4240b26b3d47">
<img width="850" alt="function and exception after" src="https://github.com/arktypeio/arktype/assets/47674925/f199a9b2-2e1b-4486-b047-1ba65c14b876">
<img width="321" alt="decorator after" src="https://github.com/arktypeio/arktype/assets/47674925/15f988c8-0e76-44ad-b61e-1695647d6a70">

