### PR TITLE
fix: correctly highlight decorators in classes as well as in global scope

### DIFF
--- a/ark/dark/color-theme.json
+++ b/ark/dark/color-theme.json
@@ -32,7 +32,7 @@
 		},
 		{
 			"name": "decorators",
-			"scope": ["punctuation.definition.decorator"],
+			"scope": ["meta.function.decorator punctuation", "meta.function.decorator support.type"],
 			"settings": {
 				"foreground": "#80cff8",
 			}


### PR DESCRIPTION
Fixes highlighting of decorators inside classes in python files. Also made sure this didn't break highlighting of decorators outside of functions, which it doesn't.

Before:
<img width="194" alt="class deco before" src="https://github.com/arktypeio/arktype/assets/47674925/74fc9a69-9151-438c-a5fa-351a986ce11a">

After:
<img width="186" alt="class deco after" src="https://github.com/arktypeio/arktype/assets/47674925/58fbb85c-1cd3-4169-86df-7e6c77594891">
