### PR TITLE
fix: inference failure for certain recursive unions

### DIFF
--- a/dev/configs/.changeset/many-tools-doubt.md
+++ b/dev/configs/.changeset/many-tools-doubt.md
@@ -1,0 +1,19 @@
+---
+"arktype": patch
+---
+
+### Fix a bug inferring certain recursive unions.
+
+Previously, a scoped type like this failed to infer correctly. Thanks to [@Vanilagy](https://github.com/Vanilagy) for the repro!
+
+```ts
+scope({
+    a: {
+        name: '"a"'
+    },
+    b: {
+        name: '"b"',
+        children: "(a|b)[]"
+    }
+})
+```

--- a/dev/test/morph.test.ts
+++ b/dev/test/morph.test.ts
@@ -299,10 +299,9 @@ describe("morph", () => {
             scope({
                 a: ["/.*/", "|>", (s) => s.trim()],
                 b: "string",
-                // @ts-expect-error
                 c: "a|b"
             }).compile()
-        }).throwsAndHasTypeError(writeUndiscriminatableMorphUnionMessage("/"))
+        }).throws(writeUndiscriminatableMorphUnionMessage("/"))
     })
     it("deep double intersection", () => {
         attest(() => {
@@ -320,10 +319,9 @@ describe("morph", () => {
             scope({
                 a: { a: ["string", "|>", (s) => s.trim()] },
                 b: { a: "'foo'" },
-                // @ts-expect-error
                 c: "a|b"
             }).compile()
-        }).throwsAndHasTypeError(writeUndiscriminatableMorphUnionMessage("/"))
+        }).throws(writeUndiscriminatableMorphUnionMessage("/"))
     })
     it("deep undiscriminated reference", () => {
         const $ = scope({
@@ -341,9 +339,8 @@ describe("morph", () => {
               }
         >
         attest(() => {
-            // @ts-expect-error
             $.type("a|c")
-        }).throwsAndHasTypeError(writeUndiscriminatableMorphUnionMessage("/"))
+        }).throws(writeUndiscriminatableMorphUnionMessage("/"))
     })
     it("array double intersection", () => {
         attest(() => {
@@ -361,12 +358,9 @@ describe("morph", () => {
             scope({
                 a: { a: ["string", "|>", (s) => s.trim()] },
                 b: { b: "boolean" },
-                // @ts-expect-error
                 c: { key: "a|b" }
             }).compile()
-        })
-            .throws(writeUndiscriminatableMorphUnionMessage("key"))
-            .types.errors(writeUndiscriminatableMorphUnionMessage("/"))
+        }).throws(writeUndiscriminatableMorphUnionMessage("key"))
     })
     it("helper morph intersection", () => {
         attest(() =>

--- a/src/parse/ast/ast.ts
+++ b/src/parse/ast/ast.ts
@@ -55,16 +55,8 @@ export type validateExpression<
         ? validateAst<operand, $>
         : never
     : ast extends InfixExpression<infer operator, infer l, infer r>
-    ? operator extends "&"
-        ? tryCatch<
-              inferIntersection<inferAst<l, $>, inferAst<r, $>>,
-              validateInfix<ast, $>
-          >
-        : operator extends "|"
-        ? tryCatch<
-              inferUnion<inferAst<l, $>, inferAst<r, $>>,
-              validateInfix<ast, $>
-          >
+    ? operator extends "&" | "|"
+        ? validateInfix<ast, $>
         : operator extends Scanner.Comparator
         ? validateBound<l, r, $>
         : operator extends "%"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
