### PR TITLE
feat: preserve name of inferred class when not including morphs

### DIFF
--- a/dev/configs/.changeset/chilly-jeans-carry.md
+++ b/dev/configs/.changeset/chilly-jeans-carry.md
@@ -1,0 +1,5 @@
+---
+"arktype": patch
+---
+
+Preserve named classes not including morphs

--- a/src/scopes/type.ts
+++ b/src/scopes/type.ts
@@ -105,9 +105,9 @@ export type AnonymousTypeName = `λ${string}`
 export const isAnonymousName = (name: string): name is AnonymousTypeName =>
     name[0] === "λ"
 
-export type asIn<t> = asIo<t, "in">
+export type asIn<t> = asIo<t, "in"> extends t ? t : asIo<t, "in">
 
-export type asOut<t> = asIo<t, "out">
+export type asOut<t> = asIo<t, "out"> extends t ? t : asIo<t, "out">
 
 type asIo<t, io extends "in" | "out"> = t extends ParsedMorph<infer i, infer o>
     ? io extends "in"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
