### PR TITLE
fix: ensure optional paths are not used as discriminants

### DIFF
--- a/dev/configs/.changeset/unlucky-kangaroos-divide.md
+++ b/dev/configs/.changeset/unlucky-kangaroos-divide.md
@@ -1,0 +1,5 @@
+---
+"arktype": patch
+---
+
+Fix an issue where optional paths could be used as discriminants

--- a/dev/test/discriminate.test.ts
+++ b/dev/test/discriminate.test.ts
@@ -77,6 +77,79 @@ describe("discriminate", () => {
             ]
         ])
     })
+    it("doesn't discriminate optional key", () => {
+        const a = type({
+            direction: "'forward' | 'backward'",
+            "operator?": "'by'"
+        })
+
+        const b = type({
+            duration: "'s' | 'min' | 'h'",
+            operator: "'to'"
+        })
+
+        const c = type([a, "|", b])
+        attest(c.flat).snap([
+            ["domain", "object"],
+            [
+                "branches",
+                [
+                    [
+                        [
+                            "requiredProp",
+                            [
+                                "direction",
+                                [
+                                    ["domain", "string"],
+                                    [
+                                        "switch",
+                                        {
+                                            path: [],
+                                            kind: "value",
+                                            cases: {
+                                                "'forward'": [],
+                                                "'backward'": []
+                                            }
+                                        }
+                                    ]
+                                ]
+                            ]
+                        ],
+                        ["optionalProp", ["operator", [["value", "by"]]]]
+                    ],
+                    [
+                        [
+                            "requiredProp",
+                            [
+                                "duration",
+                                [
+                                    ["domain", "string"],
+                                    [
+                                        "switch",
+                                        {
+                                            path: [],
+                                            kind: "value",
+                                            cases: {
+                                                "'s'": [],
+                                                "'min'": [],
+                                                "'h'": []
+                                            }
+                                        }
+                                    ]
+                                ]
+                            ]
+                        ],
+                        ["requiredProp", ["operator", [["value", "to"]]]]
+                    ]
+                ]
+            ]
+        ])
+        attest(
+            c.allows({
+                direction: "forward"
+            })
+        ).equals(true)
+    })
 
     it("undiscriminatable", () => {
         const t = getPlaces().type([

--- a/src/nodes/compose.ts
+++ b/src/nodes/compose.ts
@@ -112,6 +112,8 @@ export type DisjointKind = keyof DisjointKinds
 
 export class IntersectionState {
     path = new Path()
+    lOptional = false
+    rOptional = false
     domain: Domain | undefined
     #disjoints: DisjointsByPath = {}
 
@@ -126,7 +128,13 @@ export class IntersectionState {
         l: DisjointKinds[kind]["l"],
         r: DisjointKinds[kind]["r"]
     ): Empty {
-        this.#disjoints[`${this.path}`] = { kind, l, r }
+        this.#disjoints[`${this.path}`] = {
+            kind,
+            l,
+            r,
+            lOptional: this.lOptional,
+            rOptional: this.rOptional
+        }
         return empty
     }
 }
@@ -135,6 +143,8 @@ export type DisjointsByPath = Record<string, DisjointContext>
 
 export type DisjointContext<kind extends DisjointKind = DisjointKind> = {
     kind: kind
+    lOptional: boolean
+    rOptional: boolean
 } & DisjointKinds[kind]
 
 const empty = Symbol("empty")

--- a/src/nodes/discriminate.ts
+++ b/src/nodes/discriminate.ts
@@ -244,8 +244,12 @@ const calculateDiscriminants = (
                     // https://github.com/arktypeio/arktype/issues/593
                     continue
                 }
-                const { l, r, kind } = intersectionState.disjoints[path]
+                const { l, r, kind, lOptional, rOptional } =
+                    intersectionState.disjoints[path]
                 if (!isKeyOf(kind, discriminantKinds)) {
+                    continue
+                }
+                if (lOptional || rOptional) {
                     continue
                 }
                 const lSerialized = serializeDefinitionIfAllowed(kind, l)

--- a/src/nodes/rules/props.ts
+++ b/src/nodes/rules/props.ts
@@ -145,9 +145,15 @@ const propKeysIntersection = composeKeyedIntersection<PropsRule>(
             return l
         }
         context.path.push(propKey)
+        const previousLOptional = context.lOptional
+        const previousROptional = context.rOptional
+        context.lOptional ||= isOptional(l)
+        context.rOptional ||= isOptional(r)
         const result = nodeIntersection(propToNode(l), propToNode(r), context)
+        const resultIsOptional = context.lOptional && context.rOptional
+        context.rOptional = previousROptional
+        context.lOptional = previousLOptional
         context.path.pop()
-        const resultIsOptional = isOptional(l) && isOptional(r)
         if (isDisjoint(result) && resultIsOptional) {
             // If an optional key has an empty intersection, the type can
             // still be satisfied as long as the key is not included. Set


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
