### PR TITLE
fix: allow instanceof abstract classes, avoid inferring some function props as morphs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Install dependencies and perform setup for https://github.com/arkty
 
 inputs:
     node:
-        default: lts/*
+        default: 18
 
 runs:
     using: composite

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,14 +29,12 @@ jobs:
         timeout-minutes: 20
         strategy:
             matrix:
-                node: [lts/*]
+                # https://github.com/arktypeio/arktype/issues/738
+                node: [16, 18]
                 os: [windows-latest, macos-latest]
                 include:
                     - os: ubuntu-latest
-                      node: lts/-1
-                    # https://github.com/arktypeio/arktype/issues/738
-                    # - os: ubuntu-latest
-                    #   node: latest
+                      node: 16
             fail-fast: false
 
         runs-on: ${{ matrix.os }}

--- a/dev/configs/.changeset/fast-onions-boil.md
+++ b/dev/configs/.changeset/fast-onions-boil.md
@@ -1,0 +1,5 @@
+---
+"arktype": patch
+---
+
+Allow instanceof abstract classes, avoid treating some function props as morphs

--- a/dev/test/instanceof.test.ts
+++ b/dev/test/instanceof.test.ts
@@ -24,6 +24,18 @@ describe("instanceof", () => {
             "Must be an instance of TypeError (was Error)"
         )
     })
+    it("abstract", () => {
+        abstract class Base {
+            abstract foo: string
+        }
+        class Sub extends Base {
+            foo = ""
+        }
+        const t = type(["instanceof", Base])
+        attest(t.infer).typed as Base
+        const sub = new Sub()
+        attest(t(sub).data).equals(sub)
+    })
     it("builtins not evaluated", () => {
         const t = type(["instanceof", Date])
         attest(t.infer).types.toString("Date")

--- a/src/parse/ast/intersection.ts
+++ b/src/parse/ast/intersection.ts
@@ -3,7 +3,7 @@ import { disjointDescriptionWriters } from "../../nodes/compose.js"
 import type { asConst, evaluate, isAny, List } from "../../utils/generics.js"
 import { objectKeysOf } from "../../utils/generics.js"
 import type { Path, pathToString } from "../../utils/paths.js"
-import type { ParsedMorph } from "./morph.js"
+import type { Out, ParsedMorph } from "./morph.js"
 
 export type inferIntersection<l, r> = [l] extends [never]
     ? never
@@ -16,9 +16,9 @@ export type inferIntersection<l, r> = [l] extends [never]
     : l extends ParsedMorph<infer lIn, infer lOut>
     ? r extends ParsedMorph
         ? never
-        : (In: evaluate<lIn & r>) => lOut
+        : (In: evaluate<lIn & r>) => Out<lOut>
     : r extends ParsedMorph<infer rIn, infer rOut>
-    ? (In: evaluate<rIn & l>) => rOut
+    ? (In: evaluate<rIn & l>) => Out<rOut>
     : intersectObjects<l, r> extends infer result
     ? result
     : never

--- a/src/parse/ast/morph.ts
+++ b/src/parse/ast/morph.ts
@@ -65,10 +65,14 @@ export type validateMorphTuple<def extends TupleExpression, $> = readonly [
 
 export type Morph<i = any, o = unknown> = (In: i, problems: Problems) => o
 
-export type ParsedMorph<i = any, o = unknown> = (In: i) => o
+export type Out<o = unknown> = readonly ["|>", o]
+
+export type ParsedMorph<i = any, o = unknown> = (In: i) => Out<o>
 
 export type inferMorph<inDef, morph, $> = morph extends Morph
-    ? (In: asIn<inferDefinition<inDef, $>>) => inferMorphOut<ReturnType<morph>>
+    ? (
+          In: asIn<inferDefinition<inDef, $>>
+      ) => Out<inferMorphOut<ReturnType<morph>>>
     : never
 
 type inferMorphOut<out> = [out] extends [CheckResult<infer t>]

--- a/src/scopes/ark.ts
+++ b/src/scopes/ark.ts
@@ -1,3 +1,4 @@
+import type { Out } from "../parse/ast/morph.js"
 import { jsObjects, jsObjectsScope } from "./jsObjects.js"
 import type { Space } from "./scope.js"
 import { rootScope, scope } from "./scope.js"
@@ -60,10 +61,10 @@ export type PrecompiledDefaults = {
     email: string
     uuid: string
     semver: string
-    json: (In: string) => unknown
-    parsedNumber: (In: string) => number
-    parsedInteger: (In: string) => number
-    parsedDate: (In: string) => Date
+    json: (In: string) => Out<unknown>
+    parsedNumber: (In: string) => Out<number>
+    parsedInteger: (In: string) => Out<number>
+    parsedDate: (In: string) => Out<Date>
     // jsObjects
     Function: (...args: any[]) => unknown
     Date: Date

--- a/src/utils/generics.ts
+++ b/src/utils/generics.ts
@@ -78,7 +78,9 @@ export const isKeyOf = <k extends string | number, obj extends object>(
     obj: obj
 ): k is Extract<keyof obj, k> => k in obj
 
-export type constructor<instance = unknown> = new (...args: any[]) => instance
+export type constructor<instance = unknown> = abstract new (
+    ...args: any[]
+) => instance
 
 export type instanceOf<classType extends constructor<any>> =
     classType extends constructor<infer Instance> ? Instance : never


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
