### PR TITLE
fix: type bench can access external modules

### DIFF
--- a/ark/attest/__tests__/benchExpectedOutput.ts
+++ b/ark/attest/__tests__/benchExpectedOutput.ts
@@ -1,4 +1,4 @@
-import { bench } from "@arktype/attest"
+import { bench, type SerializedAssertionData } from "@arktype/attest"
 
 const fakeCallOptions = {
 	until: { count: 2 },
@@ -36,7 +36,11 @@ type makeComplexType<S extends string> = S extends `${infer head}${infer tail}`
 
 bench("bench type", () => {
 	return {} as makeComplexType<"defenestration">
-}).types([169, "instantiations"])
+}).types([182, "instantiations"])
+
+bench("bench type from external module", () => {
+	return {} as SerializedAssertionData
+}).types([13, "instantiations"])
 
 bench(
 	"bench call and type",
@@ -46,4 +50,4 @@ bench(
 	fakeCallOptions
 )
 	.mean([2, "ms"])
-	.types([337, "instantiations"])
+	.types([352, "instantiations"])

--- a/ark/attest/__tests__/benchExpectedOutput.ts
+++ b/ark/attest/__tests__/benchExpectedOutput.ts
@@ -37,11 +37,11 @@ type makeComplexType<S extends string> = S extends `${infer head}${infer tail}`
 
 bench("bench type", () => {
 	return {} as makeComplexType<"defenestration">
-}).types([182, "instantiations"])
+}).types([177, "instantiations"])
 
 bench("bench type from external module", () => {
 	return {} as externalmakeComplexType<"defenestration">
-}).types([206, "instantiations"])
+}).types([193, "instantiations"])
 
 bench(
 	"bench call and type",
@@ -51,6 +51,6 @@ bench(
 	fakeCallOptions
 )
 	.mean([2, "ms"])
-	.types([352, "instantiations"])
+	.types([345, "instantiations"])
 
-bench("empty", () => {}).types([13, "instantiations"])
+bench("empty", () => {}).types([0, "instantiations"])

--- a/ark/attest/__tests__/benchExpectedOutput.ts
+++ b/ark/attest/__tests__/benchExpectedOutput.ts
@@ -1,4 +1,5 @@
-import { bench, type SerializedAssertionData } from "@arktype/attest"
+import { bench } from "@arktype/attest"
+import type { makeComplexType as externalmakeComplexType } from "./utils.js"
 
 const fakeCallOptions = {
 	until: { count: 2 },
@@ -39,8 +40,8 @@ bench("bench type", () => {
 }).types([182, "instantiations"])
 
 bench("bench type from external module", () => {
-	return {} as SerializedAssertionData
-}).types([13, "instantiations"])
+	return {} as externalmakeComplexType<"defenestration">
+}).types([206, "instantiations"])
 
 bench(
 	"bench call and type",
@@ -51,3 +52,5 @@ bench(
 )
 	.mean([2, "ms"])
 	.types([352, "instantiations"])
+
+bench("empty", () => {}).types([13, "instantiations"])

--- a/ark/attest/__tests__/benchTemplate.ts
+++ b/ark/attest/__tests__/benchTemplate.ts
@@ -1,4 +1,5 @@
-import { bench, type SerializedAssertionData } from "@arktype/attest"
+import { bench } from "@arktype/attest"
+import type { makeComplexType as externalmakeComplexType } from "./utils.js"
 
 const fakeCallOptions = {
 	until: { count: 2 },
@@ -39,7 +40,7 @@ bench("bench type", () => {
 }).types()
 
 bench("bench type from external module", () => {
-	return {} as SerializedAssertionData
+	return {} as externalmakeComplexType<"defenestration">
 }).types()
 
 bench(
@@ -51,3 +52,5 @@ bench(
 )
 	.mean()
 	.types()
+
+bench("empty", () => {}).types()

--- a/ark/attest/__tests__/benchTemplate.ts
+++ b/ark/attest/__tests__/benchTemplate.ts
@@ -1,4 +1,4 @@
-import { bench } from "@arktype/attest"
+import { bench, type SerializedAssertionData } from "@arktype/attest"
 
 const fakeCallOptions = {
 	until: { count: 2 },
@@ -36,6 +36,10 @@ type makeComplexType<S extends string> = S extends `${infer head}${infer tail}`
 
 bench("bench type", () => {
 	return {} as makeComplexType<"defenestration">
+}).types()
+
+bench("bench type from external module", () => {
+	return {} as SerializedAssertionData
 }).types()
 
 bench(

--- a/ark/attest/__tests__/utils.ts
+++ b/ark/attest/__tests__/utils.ts
@@ -13,3 +13,9 @@ export const runThenGetContents = (templatePath: string) => {
 	rmSync(tempPath)
 	return resultContents
 }
+
+// type is used in benchTemplate.ts to test compatibility with external modules
+export type makeComplexType<S extends string> =
+	S extends `${infer head}${infer tail}`
+		? head | tail | makeComplexType<tail>
+		: S

--- a/ark/attest/bench/type.ts
+++ b/ark/attest/bench/type.ts
@@ -35,7 +35,12 @@ const getIsolatedEnv = () => {
 	}
 	const tsconfigInfo = getTsConfigInfoOrThrow()
 	const libFiles = getTsLibFiles(tsconfigInfo.compilerOptions)
-	const system = tsvfs.createSystem(libFiles.defaultMapFromNodeModules)
+	const projectRoot = process.cwd()
+	const system = tsvfs.createFSBackedSystem(
+		libFiles.defaultMapFromNodeModules,
+		projectRoot,
+		ts
+	)
 	__virtualEnv = tsvfs.createVirtualTypeScriptEnvironment(
 		system,
 		[],

--- a/ark/attest/bench/type.ts
+++ b/ark/attest/bench/type.ts
@@ -70,73 +70,62 @@ const getInstantiationsWithFile = (fileText: string, fileName: string) => {
 	return instantiationCount
 }
 
-const transformBenchSource = (
-	originalFile: ts.SourceFile,
-	isolatedBenchExpressionText: string,
-	includeBenchFn: boolean,
-	fakePath: string
-) => {
-	getIsolatedEnv().createFile(fakePath, originalFile.getFullText())
-	const fileToTransform = getIsolatedEnv().getSourceFile(fakePath)!
-	const currentBenchStatement =
-		getDescendants(fileToTransform).find(
-			(descendant) =>
-				descendant.kind === ts.SyntaxKind.ExpressionStatement &&
-				descendant.getText() === isolatedBenchExpressionText
-		) ??
-		throwInternalError(
-			`Could not find a bench expression with text ${isolatedBenchExpressionText}`
-		)
-	if (!includeBenchFn) {
-		return fileToTransform
-			.getFullText()
-			.replace(currentBenchStatement.getFullText(), "")
-	}
-	return fileToTransform.getText()
-}
-
 const getFirstAncestorByKindOrThrow = (node: ts.Node, kind: ts.SyntaxKind) =>
 	getAncestors(node).find((ancestor) => ancestor.kind === kind) ??
 	throwInternalError(
 		`Could not find an ancestor of kind ${ts.SyntaxKind[kind]}`
 	)
 
+const getBaselineSourceFile = (originalFile: ts.SourceFile): string => {
+	const benchCalls = getExpressionsByName(originalFile, ["bench"])
+
+	const benchExpressions = benchCalls.map((node) =>
+		getFirstAncestorByKindOrThrow(node, ts.SyntaxKind.ExpressionStatement)
+	)
+
+	let baselineSourceFileText = originalFile.getFullText()
+
+	benchExpressions.forEach((benchExpression) => {
+		baselineSourceFileText = baselineSourceFileText.replace(
+			benchExpression.getFullText(),
+			""
+		)
+	})
+
+	return baselineSourceFileText
+}
+
 const instantiationsByPath: { [path: string]: number } = {}
 
-const getInstantiationsContributedByNode = (benchCall: ts.CallExpression) => {
-	const originalFile = benchCall.getSourceFile()
+const getInstantiationsContributedByNode = (
+	benchBlock: ts.FunctionExpression | ts.ArrowFunction
+) => {
+	const originalFile = benchBlock.getSourceFile()
 	const originalPath = filePath(originalFile.fileName)
 	const fakePath = originalPath + ".nonexistent.ts"
-	const benchExpression = getFirstAncestorByKindOrThrow(
-		benchCall,
-		ts.SyntaxKind.ExpressionStatement
+
+	const baselineFile = getBaselineSourceFile(originalFile)
+
+	const baselineFileWithBenchBlock =
+		baselineFile + "\n" + benchBlock.getFullText()
+
+	const instantiationsWithNode = getInstantiationsWithFile(
+		baselineFileWithBenchBlock,
+		fakePath
 	)
-	const originalBenchExpressionText = benchExpression.getText()
+
 	if (!instantiationsByPath[fakePath]) {
 		console.log(`⏳ attest: Analyzing type assertions...`)
-		const instantiationsWithNode = getInstantiationsWithFile(
-			transformBenchSource(
-				originalFile,
-				originalBenchExpressionText,
-				true,
-				fakePath
-			),
+		const instantiationsWithoutNode = getInstantiationsWithFile(
+			baselineFile,
 			fakePath
 		)
-		instantiationsByPath[fakePath] = instantiationsWithNode
+
+		instantiationsByPath[fakePath] = instantiationsWithoutNode
 		console.log(`⏳ Cached type assertions \n`)
 	}
 
-	const instantiationsWithoutNode = getInstantiationsWithFile(
-		transformBenchSource(
-			originalFile,
-			originalBenchExpressionText,
-			false,
-			fakePath
-		),
-		fakePath
-	)
-	return instantiationsByPath[fakePath] - instantiationsWithoutNode
+	return instantiationsWithNode - instantiationsByPath[fakePath]
 }
 
 export const createBenchTypeAssertion = (
@@ -146,6 +135,7 @@ export const createBenchTypeAssertion = (
 		ctx.lastSnapCallPosition = caller()
 		const instance = TsServer.instance
 		const file = instance.getSourceFileOrThrow(ctx.benchCallPosition.file)
+
 		const benchNode = nearestCallExpressionChild(
 			file,
 			getAbsolutePosition(file, ctx.benchCallPosition)
@@ -154,9 +144,18 @@ export const createBenchTypeAssertion = (
 		if (!benchFn) {
 			throw new Error("Unable to retrieve bench expression node.")
 		}
-		const instantiationsContributed = getInstantiationsContributedByNode(
-			benchFn[0]
-		)
+
+		const benchBody = getDescendants(benchFn[0]).find(
+			(node) => ts.isArrowFunction(node) || ts.isFunctionExpression(node)
+		) as ts.ArrowFunction | ts.FunctionExpression | undefined
+
+		if (!benchBody) {
+			throw new Error("Unable to retrieve bench body node.")
+		}
+
+		const instantiationsContributed =
+			getInstantiationsContributedByNode(benchBody)
+
 		const comparison: MeasureComparison<TypeUnit> = createTypeComparison(
 			instantiationsContributed,
 			args[0]

--- a/ark/attest/tsserver/tsserver.ts
+++ b/ark/attest/tsserver/tsserver.ts
@@ -23,9 +23,7 @@ export class TsServer {
 				ts.sys,
 				dirname(this.tsConfigInfo.path)
 			)
-			.fileNames.filter(
-				(path) => path.startsWith(fromCwd()) && path.includes("__tests__")
-			)
+			.fileNames.filter((path) => path.startsWith(fromCwd()))
 
 		const system = tsvfs.createFSBackedSystem(
 			tsLibPaths.defaultMapFromNodeModules,

--- a/ark/attest/tsserver/tsserver.ts
+++ b/ark/attest/tsserver/tsserver.ts
@@ -23,7 +23,9 @@ export class TsServer {
 				ts.sys,
 				dirname(this.tsConfigInfo.path)
 			)
-			.fileNames.filter((path) => path.startsWith(fromCwd()))
+			.fileNames.filter(
+				(path) => path.startsWith(fromCwd()) && path.includes("__tests__")
+			)
 
 		const system = tsvfs.createFSBackedSystem(
 			tsLibPaths.defaultMapFromNodeModules,

--- a/ark/repo/tsup.config.ts
+++ b/ark/repo/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup"
 
 export default defineConfig({
 	entry: ["main.ts"],
-	format: ["cjs"],
+	format: ["cjs", "esm"],
 	// dts: true,
 	clean: true
 })


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally - only ran tests on attest as instructed in issue thread
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

resolves https://github.com/arktypeio/arktype/issues/884

Changes:
* type bench VFS env now uses `createFSBackedSystem` System object in order to have access to external modules
* unit test added / snapshot updated
* adds "ESM" build target in ark/repo/tsup.config.ts