### PR TITLE
 refactor: fix some typos

### DIFF
--- a/dev/attest/src/assertions.ts
+++ b/dev/attest/src/assertions.ts
@@ -2,7 +2,7 @@ import * as assert from "node:assert/strict"
 import { hasDomain } from "arktype/internal/utils/domains.js"
 import type { AssertionContext } from "./attest.js"
 
-export type ThrowAsertionErrorContext = {
+export type ThrowAssertionErrorContext = {
     message: string
     expected?: unknown
     actual?: unknown
@@ -12,7 +12,7 @@ export type ThrowAsertionErrorContext = {
 export const throwAssertionError = ({
     ctx,
     ...errorArgs
-}: ThrowAsertionErrorContext): never => {
+}: ThrowAssertionErrorContext): never => {
     const e = new assert.AssertionError(errorArgs)
     e.stack = ctx.assertionStack
     throw e

--- a/dev/attest/src/bench/type.ts
+++ b/dev/attest/src/bench/type.ts
@@ -54,7 +54,7 @@ const getInstantiationsWithFile = (fileText: string, fakePath: string) => {
 
 const transformBenchSource = (
     originalFile: SourceFile,
-    isolatedBenchExressionText: string,
+    isolatedBenchExpressionText: string,
     includeBenchFn: boolean,
     fakePath: string
 ) => {
@@ -62,7 +62,7 @@ const transformBenchSource = (
     const currentBenchStatement = fileToTransform.getFirstDescendantOrThrow(
         (node) =>
             node.isKind(SyntaxKind.ExpressionStatement) &&
-            node.getText() === isolatedBenchExressionText
+            node.getText() === isolatedBenchExpressionText
     ) as Node<ts.ExpressionStatement>
     if (!includeBenchFn) {
         emptyBenchFn(currentBenchStatement)

--- a/dev/attest/src/caller.ts
+++ b/dev/attest/src/caller.ts
@@ -40,12 +40,12 @@ const nonexistentCurrentLine = {
 
 export type FormatFilePathOptions = {
     relative?: string | boolean
-    seperator?: string
+    separator?: string
 }
 
 export const formatFilePath = (
     original: string,
-    { relative, seperator }: FormatFilePathOptions
+    { relative, separator }: FormatFilePathOptions
 ) => {
     let formatted = original
     if (original.startsWith("file:///")) {
@@ -57,10 +57,10 @@ export const formatFilePath = (
             formatted
         )
     }
-    if (seperator) {
+    if (separator) {
         formatted = formatted.replace(
             new RegExp(`\\${path.sep}`, "g"),
-            seperator
+            separator
         )
     }
     return formatted

--- a/dev/attest/src/type/internal/getAssertionsInFile.ts
+++ b/dev/attest/src/type/internal/getAssertionsInFile.ts
@@ -221,7 +221,7 @@ const checkTypeAssertion = (
 }
 
 // Using any as isTypeAssignableTo is not publicly exposed
-const getInteralTypeChecker = (project: Project) =>
+const getInternalTypeChecker = (project: Project) =>
     project.getTypeChecker().compilerObject as ts.TypeChecker & {
         isTypeAssignableTo: (first: ts.Type, second: ts.Type) => boolean
     }
@@ -230,7 +230,7 @@ const checkMutualAssignability = (
     assertionTypes: Required<AssertionTypes>,
     project: Project
 ) => {
-    const checker = getInteralTypeChecker(project)
+    const checker = getInternalTypeChecker(project)
     const isActualAssignableToExpected = checker.isTypeAssignableTo(
         assertionTypes.actual.compilerType,
         assertionTypes.expected.compilerType


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
## Overview

This PR fixes some typos. I found a few typos by [VS Code typos extension](https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode) and https://github.com/crate-ci/typos.
