### PR TITLE
feat: spread operator (...) for object literals

### DIFF
--- a/ark/type/__tests__/objectLiteral.test.ts
+++ b/ark/type/__tests__/objectLiteral.test.ts
@@ -1,6 +1,9 @@
 import { attest } from "@arktype/attest"
 import { scope, type } from "arktype"
-import { writeInvalidPropertyKeyMessage } from "../parser/objectLiteral.js"
+import {
+	writeInvalidPropertyKeyMessage,
+	writeInvalidSpreadTypeMessage
+} from "../parser/objectLiteral.js"
 import { writeUnresolvableMessage } from "../parser/string/shift/operand/unenclosed.js"
 import { writeUnboundableMessage } from "../parser/string/shift/operator/bounds.js"
 
@@ -51,6 +54,98 @@ describe("object literal", () => {
 		attest(t.json).equals({
 			basis: "object",
 			optional: [{ key: name, value: "number" }]
+		})
+	})
+	describe("spread syntax", () => {
+		it("within scope", () => {
+			const s = scope({
+				user: { isAdmin: "false", name: "string" },
+				admin: { "...": "user", isAdmin: "true" }
+			}).export()
+
+			attest<{ isAdmin: true; name: string }>(s.admin.infer)
+			attest(s.admin.json).equals({
+				basis: "object",
+				required: [
+					{ key: "isAdmin", value: { unit: true } },
+					{ key: "name", value: "string" }
+				]
+			})
+		})
+
+		it("from another `type` call", () => {
+			const user = type({ isAdmin: "false", name: "string" })
+			const admin = type({ "...": user, isAdmin: "true" })
+
+			attest<{ isAdmin: true; name: string }>(admin.infer)
+			attest(admin.json).equals({
+				basis: "object",
+				required: [
+					{ key: "isAdmin", value: { unit: true } },
+					{ key: "name", value: "string" }
+				]
+			})
+		})
+
+		it("from an object literal", () => {
+			// no idea why you'd want to do this
+			const t = type({
+				"...": {
+					inherited: "boolean",
+					overridden: "string"
+				},
+				overridden: "number"
+			})
+
+			attest<{
+				inherited: boolean
+				overridden: number
+			}>(t.infer)
+
+			attest(t.json).snap({
+				basis: "object",
+				required: [
+					{ key: "inherited", value: [{ unit: false }, { unit: true }] },
+					{ key: "overridden", value: "number" }
+				]
+			})
+		})
+
+		it("escaped key", () => {
+			const t = type({
+				"\\...": "string"
+			})
+
+			attest<{ "...": string }>(t.infer)
+
+			attest(t.json).equals({
+				basis: "object",
+				required: [{ key: "...", value: "string" }]
+			})
+		})
+
+		it("with non-object", () => {
+			// @ts-expect-error
+			attest(() => type({ "...": "string" })).throwsAndHasTypeError(
+				'Spread types may only be created from object types (was "string")'
+			)
+		})
+
+		// this is a regression test to ensure nodes are handled even if they aren't just an object
+		it("with complex type", () => {
+			const adminUser = type({
+				"...": [{ name: "string" }, "&", { isAdmin: "false" }],
+				isAdmin: "true"
+			})
+
+			attest<{ isAdmin: true; name: string }>(adminUser.infer)
+			attest(adminUser.json).snap({
+				basis: "object",
+				required: [
+					{ key: "isAdmin", value: { unit: true } },
+					{ key: "name", value: "string" }
+				]
+			})
 		})
 	})
 	describe("optional keys and definition reduction", () => {

--- a/ark/type/__tests__/objectLiteral.test.ts
+++ b/ark/type/__tests__/objectLiteral.test.ts
@@ -1,4 +1,5 @@
 import { attest } from "@arktype/attest"
+import { printable } from "@arktype/util"
 import { scope, type } from "arktype"
 import {
 	writeInvalidPropertyKeyMessage,
@@ -127,7 +128,7 @@ describe("object literal", () => {
 		it("with non-object", () => {
 			// @ts-expect-error
 			attest(() => type({ "...": "string" })).throwsAndHasTypeError(
-				'Spread types may only be created from object types (was "string")'
+				writeInvalidSpreadTypeMessage(printable("string"))
 			)
 		})
 

--- a/ark/type/parser/objectLiteral.ts
+++ b/ark/type/parser/objectLiteral.ts
@@ -104,9 +104,8 @@ export const parseObjectLiteral = (def: Dict, ctx: ParseContext) => {
 }
 
 export type inferObjectLiteral<def extends object, $, args> = evaluate<
-	merge<
-		def extends { readonly "...": infer spreadDef }
-			? inferDefinition<spreadDef, $, args>
+	merge<"..." extends keyof def 
+			? inferDefinition<def['...'], $, args>
 			: {},
 		{
 			// since def is a const parameter, we remove the readonly modifier here

--- a/ark/type/parser/objectLiteral.ts
+++ b/ark/type/parser/objectLiteral.ts
@@ -47,15 +47,9 @@ export const parseObjectLiteral = (def: Dict, ctx: ParseContext) => {
 		} else if (result.kind === "spread") {
 			const spreadNode = ctx.scope.parse(result.innerValue, ctx)
 
-			if (!spreadNode.extends(keywords.object)) {
+			if (spreadNode.kind !== "intersection" || !spreadNode.extends(keywords.object)) {
 				return throwParseError(
 					writeInvalidSpreadTypeMessage(printable(result.innerValue))
-				)
-			}
-
-			if (spreadNode.kind !== "intersection") {
-				return throwParseError(
-					`Spread operator may not be used with a ${spreadNode.kind} node`
 				)
 			}
 
@@ -99,7 +93,7 @@ export const parseObjectLiteral = (def: Dict, ctx: ParseContext) => {
 		}
 		ctx.path.pop()
 
-		hasSeenFirstKey || (hasSeenFirstKey = true)
+		hasSeenFirstKey ||= true
 	}
 
 	return schema({
@@ -192,7 +186,7 @@ type writeInvalidPropertyKeyMessage<indexDef extends string> =
 export const writeInvalidSpreadTypeMessage = <def extends string>(
 	def: def
 ): writeInvalidSpreadTypeMessage<def> =>
-	`Spread types may only be created from object types (was ${def})`
+	`Spread operand must resolve to an object literal type (was ${def})`
 
 type writeInvalidSpreadTypeMessage<def extends string> =
-	`Spread types may only be created from object types (was ${def})`
+	`Spread operand must resolve to an object literal type (was ${def})`

--- a/ark/type/parser/objectLiteral.ts
+++ b/ark/type/parser/objectLiteral.ts
@@ -1,5 +1,4 @@
-import { schema, type Inner } from "@arktype/schema"
-import { keywords } from "@arktype/schema/internal/keywords/keywords.js"
+import { keywords, schema, type Inner } from "@arktype/schema"
 import {
 	printable,
 	throwParseError,
@@ -40,11 +39,13 @@ export const parseObjectLiteral = (def: Dict, ctx: ParseContext) => {
 	for (const entry of stringAndSymbolicEntriesOf(def)) {
 		const result = parseEntry(entry)
 
-		if (result.kind === "spread" && hasSeenFirstKey) {
-			return throwParseError(
-				"Spread operator may only be used as the first key in an object"
-			)
-		} else if (result.kind === "spread") {
+		if (result.kind === "spread") {
+			if (hasSeenFirstKey) {
+				return throwParseError(
+					"Spread operator may only be used as the first key in an object"
+				)
+			}
+
 			const spreadNode = ctx.scope.parse(result.innerValue, ctx)
 
 			if (
@@ -148,10 +149,7 @@ export type validateObjectLiteral<def, $, args> = {
 			    validateDefinition<def[k], $, args>
 			  : indexParseError<writeInvalidPropertyKeyMessage<indexDef>>
 		: k extends "..."
-		  ? inferDefinition<def[k], $, args> extends Record<
-					string | number | symbol,
-					unknown
-		    >
+		  ? inferDefinition<def[k], $, args> extends object
 				? validateDefinition<def[k], $, args>
 				: indexParseError<writeInvalidSpreadTypeMessage<astToString<def[k]>>>
 		  : validateObjectValue<def[k], $, args>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

I'm not quite done yet as there are still some non-passing tests and unanswered questions.

## Questions
* [ ] What nodes other than `intersection` should be valid on the right-hand-side of `...`?
* [ ] Was `.extends(Keywords.Object)` the right choice?
