### PR TITLE
refactor: remove the `Fn` utility type

### DIFF
--- a/ark/type/match.ts
+++ b/ark/type/match.ts
@@ -1,9 +1,7 @@
 import type { Morph } from "@arktype/schema"
 import type {
-	Fn,
 	isDisjoint,
 	replaceKey,
-	returnOf,
 	unionToTuple,
 	valueOf
 } from "@arktype/util"
@@ -13,7 +11,7 @@ import { Type, type inferTypeRoot, type validateTypeRoot } from "./type.js"
 type MatchContext = {
 	inConstraint: unknown
 	outConstraint: unknown
-	thens: readonly Fn[]
+	thens: readonly ((In: unknown) => unknown)[]
 	$: unknown
 }
 
@@ -82,14 +80,12 @@ export type MatchInvocation<ctx extends MatchContext> = <
 >(
 	data: data
 ) => {
-	[i in Extract<keyof ctx["thens"], `${number}`>]: ctx["thens"][i] extends Fn<
-		[infer In],
-		infer Out
-	>
-		? isDisjoint<data, In> extends true
-			? never
-			: Out
-		: returnOf<ctx["thens"][i]>
+	[i in Extract<keyof ctx["thens"], `${number}`>]: isDisjoint<
+		data,
+		Parameters<ctx["thens"][i]>[0]
+	> extends true
+		? never
+		: ReturnType<ctx["thens"][i]>
 }[Extract<keyof ctx["thens"], `${number}`>]
 
 export type ChainableMatchParser<ctx extends MatchContext> =

--- a/ark/util/functions.ts
+++ b/ark/util/functions.ts
@@ -1,14 +1,5 @@
 import { throwInternalError } from "./errors.js"
 
-export type Fn<
-	args extends readonly unknown[] = readonly any[],
-	returns = unknown
-> = (...args: args) => returns
-
-export type paramsOf<t> = t extends Fn<infer p> ? p : never
-
-export type returnOf<t> = t extends Fn<never, infer r> ? r : never
-
 export const cached = <T>(thunk: () => T) => {
 	let isCached = false
 	let result: T | undefined

--- a/ark/util/hkt.ts
+++ b/ark/util/hkt.ts
@@ -1,4 +1,3 @@
-import type { Fn } from "./functions.js"
 import type { conform } from "./generics.js"
 
 /** A small set of HKT utility types based on https://github.com/poteat/hkt-toolbelt */
@@ -6,7 +5,9 @@ export namespace Hkt {
 	export declare const key: unique symbol
 	export type key = typeof key
 
-	export abstract class Kind<f extends Fn = Fn> {
+	export abstract class Kind<
+		f extends (...args: any[]) => unknown = (...args: any[]) => unknown
+	> {
 		declare readonly [key]: unknown
 		abstract readonly f: f
 	}

--- a/ark/util/objectKinds.ts
+++ b/ark/util/objectKinds.ts
@@ -1,5 +1,4 @@
 import { domainOf, type Domain } from "./domain.js"
-import type { Fn } from "./functions.js"
 import type { evaluate } from "./generics.js"
 import { isKeyOf } from "./records.js"
 
@@ -36,7 +35,7 @@ export type objectKindOf<
 	kinds extends ObjectKindSet = BuiltinObjectConstructors
 > = object extends data
 	? keyof kinds | undefined
-	: data extends Fn
+	: data extends (...args: any[]) => unknown
 	? "Function"
 	: instantiableObjectKind<data, kinds> extends never
 	? keyof kinds | undefined

--- a/ark/util/records.ts
+++ b/ark/util/records.ts
@@ -1,4 +1,3 @@
-import type { Fn } from "./functions.js"
 import type { defined, evaluate } from "./generics.js"
 import type { intersectUnion } from "./unionToTuple.js"
 
@@ -32,7 +31,7 @@ type requireRecurse<
 > = depth["length"] extends maxDepth
 	? o
 	: o extends object
-	? o extends Fn
+	? o extends (...args: never[]) => unknown
 		? o
 		: {
 				[k in keyof o]-?: requireRecurse<o[k], [...depth, 1], maxDepth>
@@ -58,7 +57,7 @@ type mutableRecurse<
 > = depth["length"] extends maxDepth
 	? o
 	: o extends object
-	? o extends Fn
+	? o extends (...args: never[]) => unknown
 		? o
 		: {
 				-readonly [k in keyof o]: mutableRecurse<o[k], [...depth, 1], maxDepth>

--- a/ark/util/unionToTuple.ts
+++ b/ark/util/unionToTuple.ts
@@ -1,4 +1,3 @@
-import type { Fn } from "./functions.js"
 import type { conform } from "./generics.js"
 import type { join } from "./lists.js"
 
@@ -31,7 +30,7 @@ export type intersectUnion<t> = (
 
 // Based on: https://tsplay.dev/WvydBm
 export type overloadOf<
-	f extends Fn,
+	f extends (...args: never[]) => unknown,
 	givenArgs extends readonly unknown[] = readonly unknown[]
 > = Exclude<
 	collectSignatures<


### PR DESCRIPTION
This commit removes the `Fn` utility type and replaces all of its uses with its definition, along with phasing out its custom parameters and return type utilities in favor of the lib.d.ts versions.

Causes conflicts in #904.

<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
