### PR TITLE
fix(attest): Use user-provided tsconfig.json path

### DIFF
--- a/ark/attest/cache/ts.ts
+++ b/ark/attest/cache/ts.ts
@@ -3,6 +3,7 @@ import * as tsvfs from "@typescript/vfs"
 import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import ts from "typescript"
+import { getConfig } from "../config.js"
 
 export class TsServer {
 	rootFiles!: string[]
@@ -99,13 +100,14 @@ export type TsconfigInfo = {
 }
 
 export const getTsConfigInfoOrThrow = (): TsconfigInfo => {
-	const configFilePath = ts.findConfigFile(
-		fromCwd(),
-		ts.sys.fileExists,
-		"tsconfig.json"
-	)
+	const config = getConfig()
+	const configFilePath =
+		config.tsconfig ??
+		ts.findConfigFile(fromCwd(), ts.sys.fileExists, "tsconfig.json")
 	if (!configFilePath) {
-		throw new Error(`File ${join(fromCwd(), "tsconfig.json")} must exist.`)
+		throw new Error(
+			`File ${config.tsconfig ?? join(fromCwd(), "tsconfig.json")} must exist.`
+		)
 	}
 
 	const configFileText = readFileSync(configFilePath).toString()


### PR DESCRIPTION
The `tsconfig` config option is no longer ignored when instantiating the TypeScript environment.

<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
        There were preexisting issues
* [ ] There are new or updated unit tests validating the change
        I didn't find existing tests for config options, and wasn't sure I wanted to invent that for this PR.

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

Fixes https://github.com/arktypeio/arktype/issues/919