### PR TITLE
docs(attest): use namespace import to avoid name collision in README

### DIFF
--- a/ark/attest/README.md
+++ b/ark/attest/README.md
@@ -37,12 +37,12 @@ export default defineConfig({
 `setupVitest.ts`
 
 ```ts
-import { setup, teardown } from "@arktype/attest"
+import * as attest from "@arktype/attest"
 
 // config options can be passed here
-export const setup = () => setup({})
+export const setup = () => attest.setup({})
 
-export const teardown = teardown
+export const teardown = attest.teardown
 ```
 
 ### Mocha


### PR DESCRIPTION
Hey @ssalbdivad! Here's a quick fix for the attest docs. Let me know if you have any feedback.