### PR TITLE
Fix paths for Windows users

### DIFF
--- a/ark/attest/cache/ts.ts
+++ b/ark/attest/cache/ts.ts
@@ -2,7 +2,7 @@ import { fromCwd, type SourcePosition } from "@arktype/fs"
 import { throwInternalError } from "@arktype/util"
 import * as tsvfs from "@typescript/vfs"
 import { readFileSync } from "node:fs"
-import { dirname, join } from "node:path"
+import path, { dirname, join } from "node:path"
 import ts from "typescript"
 import { getConfig } from "../config.js"
 
@@ -20,8 +20,8 @@ export class TsServer {
 
 		const tsLibPaths = getTsLibFiles(tsConfigInfo.parsed.options)
 
-		this.rootFiles = tsConfigInfo.parsed.fileNames.filter(path =>
-			path.startsWith(fromCwd())
+		this.rootFiles = tsConfigInfo.parsed.fileNames.filter(filePath => 
+			path.normalize(filePath).startsWith(fromCwd())
 		)
 
 		const system = tsvfs.createFSBackedSystem(


### PR DESCRIPTION
Under Windows:
- `fromCwd()` returns a string with backslashes.
- `ts.parseJsonConfigFileContent` returns the paths with slashes.

This causes `this.rootFiles = tsConfigInfo.parsed.fileNames.filter(path => path.startsWith(fromCwd()));` to match no files.

With this update the path check is safer.