### PR TITLE
fix(ArkDark): Add `meta.function-call.python` highlighting

### DIFF
--- a/ark/dark/color-theme.json
+++ b/ark/dark/color-theme.json
@@ -7,6 +7,7 @@
 			"scope": [
 				"entity.name.function",
 				"support.function",
+				"meta.function-call.python",
 				// We have this for Python in honor of contributor TizzySaurus.
 				// Will be removed for consistency once they allow it or the next time someone complains about it.
 				"meta.function.decorator punctuation",


### PR DESCRIPTION
## What
Adds highlighting for `meta.function-call.python`.

## Why
Highlighting for `meta.function-call` was removed [removed in b989a6](https://github.com/arktypeio/arktype/commit/b989a609704080373f1fe14f1c1fdac5035310d7#diff-5e905b02abde283f0e8a6890c4b4e0899cf2cd86c64b5004704264e7bba17a74L9), presumably to fix a highlight bug in js/ts, but this broke the highlighting for Python.

Adding `meta.function-call.python` means Python can keep the function call highlighting, whilst not conflicting with the js/ts highlighting.

## Screenshots

### Before
![image](https://github.com/arktypeio/arktype/assets/47674925/8b404e8b-b3aa-4f52-af39-bfe275ea5c26)

### After
<img width="623" alt="image" src="https://github.com/arktypeio/arktype/assets/47674925/ff65d584-207f-4607-b4dd-11f7e44b6096">

