### PR TITLE
fix consecutive narrow inference, nested pipes

### DIFF
--- a/.changeset/healthy-numbers-play.md
+++ b/.changeset/healthy-numbers-play.md
@@ -1,0 +1,5 @@
+---
+"@arktype/util": patch
+---
+
+Provide recommended tsconfig via

--- a/.changeset/healthy-numbers-play.md
+++ b/.changeset/healthy-numbers-play.md
@@ -2,4 +2,13 @@
 "@arktype/util": patch
 ---
 
-Provide recommended tsconfig via
+Provide recommended tsconfig via `tsconfig.base.json`, e.g.:
+
+`tsconfig.json`
+
+```ts
+{
+	"extends": "@arktype/util/tsconfig.base.json",
+	// your settings here
+}
+```

--- a/.changeset/little-icons-impress.md
+++ b/.changeset/little-icons-impress.md
@@ -1,0 +1,5 @@
+---
+"@arktype/schema": patch
+---
+
+Pipe and narrow bug fixes (see arktype CHANGELOG)

--- a/.changeset/little-icons-impress.md
+++ b/.changeset/little-icons-impress.md
@@ -2,4 +2,4 @@
 "@arktype/schema": patch
 ---
 
-Pipe and narrow bug fixes (see arktype CHANGELOG)
+Pipe and narrow bug fixes (see [arktype CHANGELOG](../type/CHANGELOG.md))

--- a/ark/attest/__tests__/snapPopulation.test.ts
+++ b/ark/attest/__tests__/snapPopulation.test.ts
@@ -10,7 +10,7 @@ contextualize(() => {
 			fromHere("benchExpectedOutput.ts")
 		).replaceAll("\r\n", "\n")
 		equal(actual, expectedOutput)
-	}).timeout(10000)
+	}).timeout(20000)
 
 	it("snap populates file", () => {
 		const actual = runThenGetContents(fromHere("snapTemplate.ts"))
@@ -18,5 +18,5 @@ contextualize(() => {
 			fromHere("snapExpectedOutput.ts")
 		).replaceAll("\r\n", "\n")
 		equal(actual, expectedOutput)
-	}).timeout(10000)
+	}).timeout(20000)
 })

--- a/ark/schema/ast.ts
+++ b/ark/schema/ast.ts
@@ -227,6 +227,17 @@ export type constrain<
 	kind extends PrimitiveConstraintKind,
 	schema extends NodeSchema<kind>
 > =
+	_constrain<t, kind, schema> extends infer constrained ?
+		[t, constrained] extends [constrained, t] ?
+			t
+		:	constrained
+	:	never
+
+type _constrain<
+	t,
+	kind extends PrimitiveConstraintKind,
+	schema extends NodeSchema<kind>
+> =
 	schemaToConstraint<kind, schema> extends infer constraint ?
 		t extends of<infer base, infer constraints> ?
 			[number, base] extends [base, number] ?

--- a/ark/schema/node.ts
+++ b/ark/schema/node.ts
@@ -168,6 +168,12 @@ export abstract class BaseNode<
 		return this.typeHash === other.typeHash
 	}
 
+	assertHasKind<kind extends NodeKind>(kind: kind): Node<kind> {
+		if (!this.kind === (kind as never))
+			throwError(`${this.kind} node was not of asserted kind ${kind}`)
+		return this as never
+	}
+
 	hasKind<kind extends NodeKind>(kind: kind): this is Node<kind> {
 		return this.kind === (kind as never)
 	}

--- a/ark/schema/node.ts
+++ b/ark/schema/node.ts
@@ -41,6 +41,7 @@ import {
 	type TraverseAllows,
 	type TraverseApply
 } from "./shared/traversal.js"
+import type { arkKind } from "./shared/utils.js"
 
 export type UnknownNode = BaseNode | Root
 
@@ -117,13 +118,13 @@ export abstract class BaseNode<
 	// decorator from @arktype/util on these for now
 	// as they cause a deopt in V8
 	private _in?: BaseNode;
-	get in(): BaseNode {
+	get in(): this extends { [arkKind]: "root" } ? BaseRoot : BaseNode {
 		this._in ??= this.getIo("in")
 		return this._in as never
 	}
 
 	private _out?: BaseNode
-	get out(): BaseNode {
+	get out(): this extends { [arkKind]: "root" } ? BaseRoot : BaseNode {
 		this._out ??= this.getIo("out")
 		return this._out as never
 	}

--- a/ark/schema/predicate.ts
+++ b/ark/schema/predicate.ts
@@ -97,9 +97,9 @@ export type PredicateCast<input = never, narrowed extends input = input> = (
 	ctx: TraversalContext
 ) => input is narrowed
 
-export type inferNarrow<In, predicate> =
+export type inferNarrow<t, predicate> =
 	predicate extends (data: any, ...args: any[]) => data is infer narrowed ?
-		In extends of<unknown, infer constraints> ?
+		t extends of<unknown, infer constraints> ?
 			constrain<of<narrowed, constraints>, "predicate", any>
 		:	constrain<narrowed, "predicate", any>
-	:	constrain<In, "predicate", any>
+	:	constrain<t, "predicate", any>

--- a/ark/schema/roots/intersection.ts
+++ b/ark/schema/roots/intersection.ts
@@ -329,7 +329,7 @@ export const intersectionImplementation: nodeImplementationOf<IntersectionDeclar
 					node.children.map(child => child.description).join(" and "),
 			expected: source =>
 				`  • ${source.errors.map(e => e.expected).join("\n  • ")}`,
-			problem: ctx => `must be...\n${ctx.expected}`
+			problem: ctx => `${ctx.actual} must be...\n${ctx.expected}`
 		},
 		intersections: {
 			intersection: (l, r, ctx) => intersectIntersections(l, r, ctx),

--- a/ark/schema/roots/morph.ts
+++ b/ark/schema/roots/morph.ts
@@ -160,10 +160,12 @@ export class MorphNode extends BaseRoot<MorphDeclaration> {
 		return this.inner.in
 	}
 
-	get validatedOut(): BaseRoot | undefined {
-		const lastMorph = this.inner.morphs.at(-1)
-		return hasArkKind(lastMorph, "root") ? lastMorph?.out : undefined
-	}
+	lastMorph = this.inner.morphs.at(-1)
+	validatedOut: BaseRoot | undefined =
+		hasArkKind(this.lastMorph, "root") ?
+			Object.assign(this.referencesById, this.lastMorph.out.referencesById) &&
+			this.lastMorph.out
+		:	undefined
 
 	override get out(): BaseRoot {
 		return this.validatedOut ?? this.$.keywords.unknown.raw
@@ -211,7 +213,6 @@ export type includesMorphsOrConstraints<t> =
 		false
 	:	true
 
-// TODO: this would return false on morphs within a single type
 export type includesMorphs<t> =
 	[
 		_distill<t, "in", "constrainable">,

--- a/ark/schema/roots/morph.ts
+++ b/ark/schema/roots/morph.ts
@@ -141,8 +141,8 @@ export class MorphNode extends BaseRoot<MorphDeclaration> {
 		this.in.traverseAllows(data, ctx)
 
 	traverseApply: TraverseApply = (data, ctx) => {
-		ctx.queueMorphs(this.morphs)
 		this.in.traverseApply(data, ctx)
+		ctx.queueMorphs(this.morphs)
 	}
 
 	expression = `(In: ${this.in.expression}) => Out<${this.out?.expression ?? "unknown"}>`
@@ -152,8 +152,8 @@ export class MorphNode extends BaseRoot<MorphDeclaration> {
 			js.return(js.invoke(this.in))
 			return
 		}
-		js.line(`ctx.queueMorphs(${this.compiledMorphs})`)
 		js.line(js.invoke(this.in))
+		js.line(`ctx.queueMorphs(${this.compiledMorphs})`)
 	}
 
 	override get in(): BaseRoot {

--- a/ark/schema/roots/morph.ts
+++ b/ark/schema/roots/morph.ts
@@ -162,9 +162,7 @@ export class MorphNode extends BaseRoot<MorphDeclaration> {
 
 	get validatedOut(): BaseRoot | undefined {
 		const lastMorph = this.inner.morphs.at(-1)
-		return hasArkKind(lastMorph, "root") ?
-				(lastMorph?.out as BaseRoot)
-			:	undefined
+		return hasArkKind(lastMorph, "root") ? lastMorph?.out : undefined
 	}
 
 	override get out(): BaseRoot {
@@ -191,20 +189,35 @@ export type inferMorphOut<morph extends Morph> = Exclude<
 >
 
 export type distillIn<t> =
-	includesMorphs<t> extends true ? _distill<t, "in", "base"> : t
+	includesMorphsOrConstraints<t> extends true ? _distill<t, "in", "base"> : t
 
 export type distillOut<t> =
-	includesMorphs<t> extends true ? _distill<t, "out", "base"> : t
+	includesMorphsOrConstraints<t> extends true ? _distill<t, "out", "base"> : t
 
 export type distillConstrainableIn<t> =
-	includesMorphs<t> extends true ? _distill<t, "in", "constrainable"> : t
+	includesMorphsOrConstraints<t> extends true ?
+		_distill<t, "in", "constrainable">
+	:	t
 
 export type distillConstrainableOut<t> =
-	includesMorphs<t> extends true ? _distill<t, "out", "constrainable"> : t
+	includesMorphsOrConstraints<t> extends true ?
+		_distill<t, "out", "constrainable">
+	:	t
 
-export type includesMorphs<t> =
+export type includesMorphsOrConstraints<t> =
 	[t, _distill<t, "in", "base">, t, _distill<t, "out", "base">] extends (
 		[_distill<t, "in", "base">, t, _distill<t, "out", "base">, t]
+	) ?
+		false
+	:	true
+
+// TODO: this would return false on morphs within a single type
+export type includesMorphs<t> =
+	[
+		_distill<t, "in", "constrainable">,
+		_distill<t, "out", "constrainable">
+	] extends (
+		[_distill<t, "out", "constrainable">, _distill<t, "in", "constrainable">]
 	) ?
 		false
 	:	true

--- a/ark/schema/roots/root.ts
+++ b/ark/schema/roots/root.ts
@@ -179,8 +179,11 @@ export abstract class BaseRoot<
 	}
 
 	private pipeOnce(morph: Morph): BaseRoot {
-		if (hasArkKind(morph, "root"))
-			return pipeNodesRoot(this, morph, this.$) as never
+		if (hasArkKind(morph, "root")) {
+			const result = pipeNodesRoot(this, morph, this.$)
+			if (result instanceof Disjoint) return result.throw()
+			return result as BaseRoot
+		}
 		if (this.hasKind("union")) {
 			const branches = this.branches.map(node => node.pipe(morph))
 			return this.$.node("union", { ...this.inner, branches })

--- a/ark/schema/roots/root.ts
+++ b/ark/schema/roots/root.ts
@@ -168,7 +168,7 @@ export abstract class BaseRoot<
 		return this.configure(description)
 	}
 
-	create(input: unknown): unknown {
+	from(input: unknown): unknown {
 		// ideally we wouldn't validate here but for now we need to do determine
 		// which morphs to apply
 		return this.assert(input)
@@ -198,15 +198,30 @@ export abstract class BaseRoot<
 	}
 
 	narrow(predicate: Predicate): BaseRoot {
-		return this.constrain("predicate", predicate)
+		return this.constrainOut("predicate", predicate)
 	}
 
 	constrain<kind extends PrimitiveConstraintKind>(
 		kind: kind,
 		schema: NodeSchema<kind>
 	): BaseRoot {
+		return this._constrain("in", kind, schema)
+	}
+
+	constrainOut<kind extends PrimitiveConstraintKind>(
+		kind: kind,
+		schema: NodeSchema<kind>
+	): BaseRoot {
+		return this._constrain("out", kind, schema)
+	}
+
+	private _constrain(
+		io: "in" | "out",
+		kind: PrimitiveConstraintKind,
+		schema: any
+	): BaseRoot {
 		const constraint = this.$.node(kind, schema)
-		if (constraint.impliedBasis && !this.extends(constraint.impliedBasis)) {
+		if (constraint.impliedBasis && !this[io].extends(constraint.impliedBasis)) {
 			return throwInvalidOperandError(
 				kind,
 				constraint.impliedBasis as never,
@@ -214,12 +229,18 @@ export abstract class BaseRoot<
 			)
 		}
 
-		return this.and(
-			// TODO: not an intersection
-			this.$.node("intersection", {
-				[kind]: constraint
-			})
-		)
+		const partialIntersection = this.$.node("intersection", {
+			[kind]: constraint
+		})
+
+		const result =
+			io === "in" ?
+				intersectNodesRoot(this, partialIntersection, this.$)
+			:	pipeNodesRoot(this, partialIntersection, this.$)
+
+		if (result instanceof Disjoint) result.throw()
+
+		return result as never
 	}
 
 	onUndeclaredKey(undeclared: UndeclaredKeyBehavior): BaseRoot {
@@ -331,7 +352,7 @@ export declare abstract class InnerRoot<t = unknown, $ = any> extends Callable<
 
 	onUndeclaredKey(behavior: UndeclaredKeyBehavior): this
 
-	create(literal: this["inferIn"]): this["infer"]
+	from(literal: this["inferIn"]): this["infer"]
 }
 
 // this is declared as a class internally so we can ensure all "abstract"

--- a/ark/schema/roots/union.ts
+++ b/ark/schema/roots/union.ts
@@ -531,7 +531,7 @@ export const reduceBranches = ({
 
 			if (intersection.equals(branches[i].in)) {
 				// preserve ordered branches that are a subtype of a subsequent branch
-				uniquenessByIndex[i] = !ordered
+				uniquenessByIndex[i] = !!ordered
 			} else if (intersection.equals(branches[j].in))
 				uniquenessByIndex[j] = false
 		}

--- a/ark/schema/roots/union.ts
+++ b/ark/schema/roots/union.ts
@@ -320,7 +320,7 @@ export class UnionNode extends BaseRoot<UnionDeclaration> {
 			const l = this.branches[lIndex]
 			for (let rIndex = lIndex + 1; rIndex < this.branches.length; rIndex++) {
 				const r = this.branches[rIndex]
-				const result = intersectNodesRoot(l, r, l.$)
+				const result = intersectNodesRoot(l.in, r.in, l.$)
 				if (!(result instanceof Disjoint)) continue
 
 				for (const { path, kind, disjoint } of result.flat) {
@@ -523,18 +523,17 @@ export const reduceBranches = ({
 				continue
 			}
 			const intersection = intersectNodesRoot(
-				branches[i],
-				branches[j],
+				branches[i].in,
+				branches[j].in,
 				branches[0].$
-			)
+			)!
 			if (intersection instanceof Disjoint) continue
 
-			if (intersection.equals(branches[i])) {
-				if (!ordered) {
-					// preserve ordered branches that are a subtype of a subsequent branch
-					uniquenessByIndex[i] = false
-				}
-			} else if (intersection.equals(branches[j])) uniquenessByIndex[j] = false
+			if (intersection.equals(branches[i].in)) {
+				// preserve ordered branches that are a subtype of a subsequent branch
+				uniquenessByIndex[i] = !ordered
+			} else if (intersection.equals(branches[j].in))
+				uniquenessByIndex[j] = false
 		}
 	}
 	return branches.filter((_, i) => uniquenessByIndex[i])

--- a/ark/schema/shared/traversal.ts
+++ b/ark/schema/shared/traversal.ts
@@ -49,7 +49,6 @@ export class TraversalContext {
 	finalize(): unknown {
 		if (this.hasError()) return this.errors
 
-		let out: any = this.root
 		if (this.queuedMorphs.length) {
 			for (let i = 0; i < this.queuedMorphs.length; i++) {
 				const { path, morphs } = this.queuedMorphs[i]
@@ -60,14 +59,17 @@ export class TraversalContext {
 
 				if (key !== undefined) {
 					// find the object on which the key to be morphed exists
-					parent = out
+					parent = this.root
 					for (let pathIndex = 0; pathIndex < path.length - 1; pathIndex++)
 						parent = parent[path[pathIndex]]
 				}
 
 				this.path = path
 				for (const morph of morphs) {
-					const result = morph(parent === undefined ? out : parent[key!], this)
+					const result = morph(
+						parent === undefined ? this.root : parent[key!],
+						this
+					)
 					if (result instanceof ArkErrors) return result
 					if (this.hasError()) return this.errors
 					if (result instanceof ArkError) {
@@ -79,12 +81,12 @@ export class TraversalContext {
 
 					// apply the morph function and assign the result to the
 					// corresponding property, or to root if path is empty
-					if (parent === undefined) out = result
+					if (parent === undefined) this.root = result
 					else parent[key!] = result
 				}
 			}
 		}
-		return out
+		return this.root
 	}
 
 	get currentErrorCount(): number {

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -2,10 +2,44 @@
 
 ## 2.0.0-dev.15
 
-- [`8cd0807`](https://github.com/arktypeio/arktype/commit/8cd080783fdbd8eefea54d5c04d99cd88b36c0eb) - Initial changeset
+- Fix a crash when piping to nested paths (see https://github.com/arktypeio/arktype/issues/968)
+- Fix inferred input type of `.narrow` (see https://github.com/arktypeio/arktype/issues/969)
+- Throw on a pipe between disjoint types, e.g.:
+
+```ts
+// Now correctly throws ParseError: Intersection of <3 and >5 results in an unsatisfiable type
+const t = type("number>5").pipe(type("number<3"))
+
+// Previously returned a Disjoint object
+```
+
+- Mention the actual value when describing an intersection error:
+
+```ts
+const evenGreaterThan5 = type({ value: "number%2>5" })
+const out = evenGreaterThan5(3)
+if (out instanceof type.errors) {
+	/*
+    value 3 must be...
+      • a multiple of 2
+      • at most 5
+    */
+	console.log(out.summary)
+}
+
+// was previously "value must be..."
+```
+
+Thanks [@TizzySaurus](https://github.com/TizzySaurus) for reporting the last two on [our Discord](arktype.io/discord)!
+
+https://github.com/arktypeio/arktype/pull/971
 
 ## 2.0.0-dev.14
 
 ### Patch Changes
 
 - Initial changeset
+
+```
+
+```

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -1,0 +1,11 @@
+# arktype
+
+## 2.0.0-dev.15
+
+- [`8cd0807`](https://github.com/arktypeio/arktype/commit/8cd080783fdbd8eefea54d5c04d99cd88b36c0eb) - Initial changeset
+
+## 2.0.0-dev.14
+
+### Patch Changes
+
+- Initial changeset

--- a/ark/type/__tests__/narrow.test.ts
+++ b/ark/type/__tests__/narrow.test.ts
@@ -104,7 +104,22 @@ contextualize(() => {
 			.pipe(s => s.length)
 			.narrow((n): n is 5 => n === 5)
 
+		const morphRef = t.raw.assertHasKind("morph").serializedMorphs[0]
+
+		const predicateRef =
+			t.raw.firstReferenceOfKindOrThrow("predicate").serializedPredicate
+
+		attest(t.json).snap({
+			in: "string",
+			morphs: [morphRef, { predicate: [predicateRef] }]
+		})
+
 		attest<Type<(In: string) => Out<of<5, Narrowed>>>>(t)
+
+		attest(t("12345")).snap(5)
+		attest(t("1234").toString()).snap(
+			"must be valid according to an anonymous predicate (was 4)"
+		)
 	})
 
 	it("expression", () => {

--- a/ark/type/__tests__/narrow.test.ts
+++ b/ark/type/__tests__/narrow.test.ts
@@ -104,11 +104,21 @@ contextualize(() => {
 			.pipe(s => s.length)
 			.narrow((n): n is 5 => n === 5)
 
-		attest<Type<(In: string) => Out<of<5, Narrowed>>, {}>>(t)
+		attest<Type<(In: string) => Out<of<5, Narrowed>>>>(t)
 	})
 
 	it("expression", () => {
 		const t = type("string", ":", (s): s is `f${string}` => s[0] === "f")
 		attest<`f${string}`>(t.infer)
 	})
+
+	// TODO: reenable
+	// https://github.com/arktypeio/arktype/issues/970
+	// it("narrows the output type of an morph within a single type", () => {
+	// 	const t = type("string")
+	// 		.pipe(s => `${s}!`)
+	// 		.narrow((s): s is "foo!" => s === "foo!")
+
+	// 	attest<Type<(In: string) => Out<of<"foo!", Narrowed>>>>(t)
+	// })
 })

--- a/ark/type/__tests__/narrow.test.ts
+++ b/ark/type/__tests__/narrow.test.ts
@@ -1,5 +1,5 @@
 import { attest, contextualize } from "@arktype/attest"
-import type { Narrowed, Out, of, string } from "@arktype/schema"
+import type { Narrowed, Out, number, of, string } from "@arktype/schema"
 import { registeredReference, type equals } from "@arktype/util"
 import { type, type Type } from "arktype"
 
@@ -28,6 +28,20 @@ contextualize(() => {
 			(n, ctx) => n % 3 === 0 || ctx.invalid("divisible by 3")
 		])
 		attest(divisibleBy3(1).toString()).snap("must be divisible by 3 (was 1)")
+	})
+
+	it("chained narrows", () => {
+		const divisibleBy30 = type("number")
+			.narrow((n, ctx) => n % 2 === 0 || ctx.invalid("divisible by 2"))
+			.narrow((n, ctx) => n % 3 === 0 || ctx.invalid("divisible by 3"))
+			.narrow((n, ctx) => n % 5 === 0 || ctx.invalid("divisible by 5"))
+
+		attest<number.narrowed>(divisibleBy30.t)
+
+		attest(divisibleBy30(1).toString()).snap("must be divisible by 2 (was 1)")
+		attest(divisibleBy30(2).toString()).snap("must be divisible by 3 (was 2)")
+		attest(divisibleBy30(6).toString()).snap("must be divisible by 5 (was 6)")
+		attest(divisibleBy30(30)).equals(30)
 	})
 
 	it("problem at path", () => {

--- a/ark/type/__tests__/pipe.test.ts
+++ b/ark/type/__tests__/pipe.test.ts
@@ -14,6 +14,12 @@ contextualize(() => {
 		attest(result.toString()).snap("must be a number (was string)")
 	})
 
+	it("disjoint", () => {
+		attest(() => type("number>5").pipe(type("number<3"))).throws.snap(
+			"ParseError: Intersection of <3 and >5 results in an unsatisfiable type"
+		)
+	})
+
 	it("within type", () => {
 		const t = type(["boolean", "=>", data => !data])
 		attest<Type<(In: boolean) => Out<boolean>>>(t)

--- a/ark/type/__tests__/traverse.test.ts
+++ b/ark/type/__tests__/traverse.test.ts
@@ -132,7 +132,7 @@ contextualize(() => {
 	it("multi", () => {
 		const naturalNumber = type("integer>0")
 		attest(naturalNumber(-1.2).toString()).snap(
-			`must be...
+			`-1.2 must be...
   • an integer
   • more than 0`
 		)
@@ -140,7 +140,7 @@ contextualize(() => {
 			natural: naturalNumber
 		})
 		attest(naturalAtPath({ natural: -0.1 }).toString()).snap(
-			`natural must be...
+			`natural -0.1 must be...
   • an integer
   • more than 0`
 		)

--- a/ark/type/package.json
+++ b/ark/type/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arktype",
 	"description": "TypeScript's 1:1 validator, optimized from editor to runtime",
-	"version": "2.0.0-dev.14",
+	"version": "2.0.0-dev.15",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/type/type.ts
+++ b/ark/type/type.ts
@@ -13,7 +13,6 @@ import {
 	type ambient,
 	type constrain,
 	type constraintKindOf,
-	type distillConstrainableOut,
 	type distillIn,
 	type distillOut,
 	type includesMorphs,
@@ -208,13 +207,12 @@ declare class _Type<t = unknown, $ = any>
 		g: g
 	): Type<inferPipes<t, [a, b, c, d, e, f, g]>, $>
 
-	// TODO: based on below, should maybe narrow morph output if used after
-	narrow<def extends Predicate<distillConstrainableOut<t>>>(
+	narrow<def extends Predicate<distillOut<t>>>(
 		def: def
 	): Type<
 		includesMorphs<t> extends true ?
-			(In: this["tIn"]) => Out<inferNarrow<this["infer"], def>>
-		:	inferNarrow<this["infer"], def>,
+			(In: this["tIn"]) => Out<inferNarrow<this["tOut"], def>>
+		:	inferNarrow<t, def>,
 		$
 	>
 

--- a/ark/util/package.json
+++ b/ark/util/package.json
@@ -12,9 +12,6 @@
 	"exports": {
 		".": "./out/api.js",
 		"./internal/*": "./out/*",
-		"./tsconfig": "./tsconfig.base.json",
-		"./tsconfig.json": "./tsconfig.base.json",
-		"./tsconfig.base": "./tsconfig.base.json",
 		"./tsconfig.base.json": "./tsconfig.base.json"
 	},
 	"files": [


### PR DESCRIPTION
- Fix a crash when piping to nested paths (see https://github.com/arktypeio/arktype/issues/968)
- Fix inferred input type of `.narrow` (see https://github.com/arktypeio/arktype/issues/969)
- Throw on a pipe between disjoint types, e.g.:

```ts
// Now correctly throws ParseError: Intersection of <3 and >5 results in an unsatisfiable type
const t = type("number>5").pipe(type("number<3"))

// Previously returned a Disjoint object
```

- Mention the actual value when describing an intersection error:

```ts
const evenGreaterThan5 = type({ value: "number%2>5" })
const out = evenGreaterThan5(3)
if (out instanceof type.errors) {
	/*
    value 3 must be...
      • a multiple of 2
      • at most 5
    */
	console.log(out.summary)
}

// was previously "value must be..."
```

Thanks [@TizzySaurus](https://github.com/TizzySaurus) for reporting the last two on [our Discord](arktype.io/discord)!