### PR TITLE
fix: propagate description on unions

### DIFF
--- a/.changeset/serious-falcons-guess.md
+++ b/.changeset/serious-falcons-guess.md
@@ -1,0 +1,5 @@
+---
+"@arktype/schema": patch
+---
+
+Fix chained .describe() on union types (see [arktype CHANGELOG](../type/CHANGELOG.md))

--- a/ark/schema/parse.ts
+++ b/ark/schema/parse.ts
@@ -8,9 +8,7 @@ import {
 	type Dict,
 	type Json,
 	type JsonData,
-	type PartialRecord,
-	type listable,
-	type propValueOf
+	type listable
 } from "@arktype/util"
 import {
 	nodeClassesByKind,
@@ -20,14 +18,12 @@ import {
 import type { BaseNode } from "./node.js"
 import type { UnknownRoot } from "./roots/root.js"
 import type { RawRootScope } from "./scope.js"
-import type { RawNodeDeclaration } from "./shared/declare.js"
 import { Disjoint } from "./shared/disjoint.js"
 import {
 	constraintKeys,
 	defaultValueSerializer,
 	isNodeKind,
 	precedenceOfKind,
-	type KeySchemainitions,
 	type NodeKind,
 	type RootKind,
 	type UnknownAttachments
@@ -52,10 +48,6 @@ export interface NodeParseContext<kind extends NodeKind = NodeKind>
 	args?: Record<string, UnknownRoot>
 	schema: NormalizedSchema<kind>
 }
-
-const baseKeys: PartialRecord<string, propValueOf<KeySchemainitions<any>>> = {
-	description: { meta: true }
-} satisfies KeySchemainitions<RawNodeDeclaration> as never
 
 export const schemaKindOf = <kind extends RootKind = RootKind>(
 	schema: unknown,
@@ -122,7 +114,7 @@ export const parseNode = (kind: NodeKind, ctx: NodeParseContext): BaseNode => {
 	const children: BaseNode[] = []
 	for (const entry of schemaEntries) {
 		const k = entry[0]
-		const keyImpl = impl.keys[k] ?? baseKeys[k]
+		const keyImpl = impl.keys[k]
 		if (!keyImpl)
 			return throwParseError(`Key ${k} is not valid on ${kind} schema`)
 
@@ -136,7 +128,7 @@ export const parseNode = (kind: NodeKind, ctx: NodeParseContext): BaseNode => {
 	let typeJson: Record<string, unknown> = {}
 	entries.forEach(([k, v]) => {
 		const listableNode = v as listable<BaseNode>
-		const keyImpl = impl.keys[k] ?? baseKeys[k]
+		const keyImpl = impl.keys[k]
 		const serialize =
 			keyImpl.serialize ??
 			(keyImpl.child ? serializeListableChild : defaultValueSerializer)

--- a/ark/schema/refinements/range.ts
+++ b/ark/schema/refinements/range.ts
@@ -7,7 +7,7 @@ import {
 import { RawPrimitiveConstraint } from "../constraint.js"
 import type { Node } from "../kinds.js"
 import type { BaseMeta, RawNodeDeclaration } from "../shared/declare.js"
-import type { KeySchemainitions, RangeKind } from "../shared/implement.js"
+import type { KeySchemaDefinitions, RangeKind } from "../shared/implement.js"
 
 export interface BaseRangeDeclaration extends RawNodeDeclaration {
 	kind: RangeKind
@@ -172,7 +172,7 @@ export type NumericallyBoundable = string | number | array
 
 export type Boundable = NumericallyBoundable | Date
 
-export const parseExclusiveKey: KeySchemainitions<BaseRangeDeclaration>["exclusive"] =
+export const parseExclusiveKey: KeySchemaDefinitions<BaseRangeDeclaration>["exclusive"] =
 	{
 		// omit key with value false since it is the default
 		parse: (flag: boolean) => flag || undefined

--- a/ark/schema/shared/implement.ts
+++ b/ark/schema/shared/implement.ts
@@ -6,11 +6,13 @@ import {
 	type Entry,
 	type Json,
 	type JsonData,
+	type PartialRecord,
 	type entryOf,
 	type indexOf,
 	type keySet,
 	type keySetOf,
 	type listable,
+	type propValueOf,
 	type requireKeys,
 	type show
 } from "@arktype/util"
@@ -233,11 +235,11 @@ export const schemaKindsRightOf = <kind extends RootKind>(
 ): schemaKindRightOf<kind>[] =>
 	rootKinds.slice(precedenceOfKind(kind) + 1) as never
 
-export type KeySchemainitions<d extends RawNodeDeclaration> = {
-	[k in keyRequiringSchemainition<d>]: NodeKeyImplementation<d, k>
+export type KeySchemaDefinitions<d extends RawNodeDeclaration> = {
+	[k in keyRequiringSchemaDefinition<d>]: NodeKeyImplementation<d, k>
 }
 
-type keyRequiringSchemainition<d extends RawNodeDeclaration> = Exclude<
+type keyRequiringSchemaDefinition<d extends RawNodeDeclaration> = Exclude<
 	keyof d["normalizedSchema"],
 	keyof BaseMeta
 >
@@ -279,7 +281,7 @@ export type NodeKeyImplementation<
 
 interface CommonNodeImplementationInput<d extends RawNodeDeclaration> {
 	kind: d["kind"]
-	keys: KeySchemainitions<d>
+	keys: KeySchemaDefinitions<d>
 	normalize: (schema: d["schema"]) => d["normalizedSchema"]
 	hasAssociatedError: d["errorContext"] extends null ? false : true
 	finalizeJson?: (json: { [k in keyof d["inner"]]: JsonData }) => Json
@@ -366,6 +368,13 @@ export interface NarrowedAttachments<d extends RawNodeDeclaration>
 	children: Node<d["childKind"]>[]
 }
 
+export const baseKeys: PartialRecord<
+	string,
+	propValueOf<KeySchemaDefinitions<any>>
+> = {
+	description: { meta: true }
+} satisfies KeySchemaDefinitions<RawNodeDeclaration> as never
+
 export const implementNode = <d extends RawNodeDeclaration = never>(
 	_: nodeImplementationInputOf<d>
 ): nodeImplementationOf<d> => {
@@ -388,5 +397,6 @@ export const implementNode = <d extends RawNodeDeclaration = never>(
 			return problemWithLocation
 		}
 	}
+	Object.assign(implementation.keys, baseKeys)
 	return implementation as never
 }

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -1,5 +1,14 @@
 # arktype
 
+## 2.0.0-dev.21
+
+### Fix chained .describe() on union types
+
+```ts
+// now correctly adds the description to the union and its branches
+const t = type("number|string").describe("My custom type")
+```
+
 ## 2.0.0-dev.20
 
 ### Fix autocomplete for private aliases

--- a/ark/type/__tests__/union.test.ts
+++ b/ark/type/__tests__/union.test.ts
@@ -259,4 +259,15 @@ contextualize(() => {
 			writeUnresolvableMessage("nummer")
 		)
 	})
+
+	it("chained description", () => {
+		const t = type("number|string").describe("My custom type")
+		attest(t.json).snap({
+			branches: [
+				{ description: "My custom type", domain: "number" },
+				{ description: "My custom type", domain: "string" }
+			],
+			description: "My custom type"
+		})
+	})
 })

--- a/ark/type/package.json
+++ b/ark/type/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arktype",
 	"description": "TypeScript's 1:1 validator, optimized from editor to runtime",
-	"version": "2.0.0-dev.20",
+	"version": "2.0.0-dev.21",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

```ts
// now correctly adds the description to the union and its branches
const t = type("number|string").describe("My custom type")
```
