### PR TITLE
perf(attest): lazy formatting for type strings

### DIFF
--- a/ark/attest/assert/chainableAssertions.ts
+++ b/ark/attest/assert/chainableAssertions.ts
@@ -238,7 +238,7 @@ export class ChainableAssertions implements AssertionRecord {
 					// if still fails somehow, just swallow the error and use the unformatted type
 				}
 			}
-			return typeString;
+			return typeString
 		}
 
 		if (this.ctx.cfg.skipTypes) return chainableNoOpProxy

--- a/ark/attest/cache/ts.ts
+++ b/ark/attest/cache/ts.ts
@@ -1,10 +1,8 @@
 import { fromCwd, type SourcePosition } from "@ark/fs"
 import { throwInternalError } from "@ark/util"
-import prettier from "@prettier/sync"
 import * as tsvfs from "@typescript/vfs"
 import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
-import type { Options as PrettierOptions } from "prettier"
 import ts from "typescript"
 import { getConfig } from "../config.js"
 
@@ -196,46 +194,10 @@ export interface StringifiableType extends ts.Type {
 	isUnresolvable: boolean
 }
 
-const declarationPrefix = "type T = "
-const typeFormatOptions: PrettierOptions = {
-	parser: "typescript",
-	semi: false,
-	useTabs: true,
-	printWidth: 60,
-	trailingComma: "none"
-}
-
-const formatTypeString = (typeString: string) =>
-	prettier
-		.format(`${declarationPrefix}${typeString}`, typeFormatOptions)
-		.slice(declarationPrefix.length)
-		.trimEnd()
-
-const replaceKnownInvalidSyntax = (typeString: string): string => {
-	// Match '...' and '... x more ...' (known truncated type syntax)
-	const regex = /\.\.\.\s*(\d+\s*more\s*\.\.\.)?/g
-
-	// replace these with a string literal "..." so that they can still
-	// form valid expressions, e.g. "..."[]
-	return typeString.replaceAll(regex, '"..."')
-}
-
 export const getStringifiableType = (node: ts.Node): StringifiableType => {
 	const typeChecker = getInternalTypeChecker()
 	const nodeType = typeChecker.getTypeAtLocation(node)
-	let stringified = typeChecker.typeToString(nodeType)
-
-	try {
-		stringified = formatTypeString(stringified)
-	} catch {
-		// if formatting fails (e.g. due to custom typeToString syntax like ... X more),
-		// try to comment out problematic sections
-		try {
-			stringified = formatTypeString(replaceKnownInvalidSyntax(stringified))
-		} catch {
-			// if still fails somehow, just swallow the error and use the unformatted type
-		}
-	}
+	const stringified = typeChecker.typeToString(nodeType)
 
 	return Object.assign(nodeType, {
 		toString: () => stringified,


### PR DESCRIPTION
This PR removes the code formatting type strings for the `typescript.json` cache file (in `ark/attest/cache/ts.ts` `getStringifiableType`), and instead applies formatting on an as-needed basis when `toString` is called on object types (relevant function in `ark/attest/assert` `chainableAssertions`).

This change reduces test run time substantially, cutting ~4.08 s from a ~11.4 s process.

Relevant PR: https://github.com/arktypeio/arktype/issues/1065