### PR TITLE
feat: add `format.normalize`

### DIFF
--- a/ark/type/__tests__/keywords.test.ts
+++ b/ark/type/__tests__/keywords.test.ts
@@ -319,6 +319,13 @@ tags[2] must be a string (was object)`)
 			attest(wellFormed("ab\uD800c")).equals("ab�c")
 			attest(wellFormed(5).toString()).snap("must be a string (was number)")
 		})
+		it("normalize", () => {
+			const normalize = type("format.normalize")
+			attest(normalize("\u00F1")).equals("ñ")
+			attest(normalize("\u006E\u0303")).equals("ñ")
+			attest(normalize("\u00F1")).equals(normalize("\u006E\u0303"))
+			attest(normalize(5).toString()).snap("must be a string (was number)")
+		})
 	})
 
 	describe("generics", () => {

--- a/ark/type/keywords/format.ts
+++ b/ark/type/keywords/format.ts
@@ -28,12 +28,18 @@ const wellFormed = rootNode({
 	morphs: (s: string) => s.toWellFormed()
 })
 
+const normalize = rootNode({
+	in: "string",
+	morphs: (s: string) => s.normalize()
+})
+
 export type formattingExports = {
 	trim: (In: string) => Out<string>
 	uppercase: (In: string) => Out<string>
 	lowercase: (In: string) => Out<string>
 	capitalize: (In: string) => Out<string>
 	wellFormed: (In: string) => Out<string>
+	normalize: (In: string) => Out<string>
 }
 export type formatting = Module<formattingExports>
 
@@ -43,7 +49,8 @@ export const formatting: formatting = scope(
 		uppercase,
 		lowercase,
 		capitalize,
-		wellFormed
+		wellFormed,
+		normalize
 	},
 	{
 		prereducedAliases: true


### PR DESCRIPTION
Adds `format.normalize`.

As discussed in https://github.com/arktypeio/arktype/issues/1073 we should expand this with all options (with backwards compatibility) in the future.