### PR TITLE
feat: add `format.capitalize`

### DIFF
--- a/ark/type/__tests__/keywords.test.ts
+++ b/ark/type/__tests__/keywords.test.ts
@@ -309,6 +309,11 @@ tags[2] must be a string (was object)`)
 			attest(uppercase("foo")).equals("FOO")
 			attest(uppercase(5).toString()).snap("must be a string (was number)")
 		})
+		it("capitalize", () => {
+			const capitalize = type("format.capitalize")
+			attest(capitalize("foo")).equals("Foo")
+			attest(capitalize(5).toString()).snap("must be a string (was number)")
+		})
 	})
 
 	describe("generics", () => {

--- a/ark/type/keywords/format.ts
+++ b/ark/type/keywords/format.ts
@@ -18,10 +18,16 @@ const lowercase = rootNode({
 	morphs: (s: string) => s.toLowerCase()
 })
 
+const capitalize = rootNode({
+	in: "string",
+	morphs: (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
+})
+
 export type formattingExports = {
 	trim: (In: string) => Out<string>
 	uppercase: (In: string) => Out<string>
 	lowercase: (In: string) => Out<string>
+	capitalize: (In: string) => Out<string>
 }
 export type formatting = Module<formattingExports>
 
@@ -29,7 +35,8 @@ export const formatting: formatting = scope(
 	{
 		trim,
 		uppercase,
-		lowercase
+		lowercase,
+		capitalize
 	},
 	{
 		prereducedAliases: true


### PR DESCRIPTION
Adds `format.capitalize` which is a non-JavaScript-native keyword.