### PR TITLE
feat: add `format.wellFormed`

### DIFF
--- a/ark/type/__tests__/keywords.test.ts
+++ b/ark/type/__tests__/keywords.test.ts
@@ -314,6 +314,11 @@ tags[2] must be a string (was object)`)
 			attest(capitalize("foo")).equals("Foo")
 			attest(capitalize(5).toString()).snap("must be a string (was number)")
 		})
+		it("wellFormed", () => {
+			const wellFormed = type("format.wellFormed")
+			attest(wellFormed("ab\uD800c")).equals("ab�c")
+			attest(wellFormed(5).toString()).snap("must be a string (was number)")
+		})
 	})
 
 	describe("generics", () => {

--- a/ark/type/keywords/format.ts
+++ b/ark/type/keywords/format.ts
@@ -23,11 +23,17 @@ const capitalize = rootNode({
 	morphs: (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
 })
 
+const wellFormed = rootNode({
+	in: "string",
+	morphs: (s: string) => s.toWellFormed()
+})
+
 export type formattingExports = {
 	trim: (In: string) => Out<string>
 	uppercase: (In: string) => Out<string>
 	lowercase: (In: string) => Out<string>
 	capitalize: (In: string) => Out<string>
+	wellFormed: (In: string) => Out<string>
 }
 export type formatting = Module<formattingExports>
 
@@ -36,7 +42,8 @@ export const formatting: formatting = scope(
 		trim,
 		uppercase,
 		lowercase,
-		capitalize
+		capitalize,
+		wellFormed
 	},
 	{
 		prereducedAliases: true


### PR DESCRIPTION
Adds support for [`string.toWellFormed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed) as `format.wellFormed`
