### PR TITLE
test: add cloned Date test

### DIFF
--- a/ark/type/__tests__/dateLiteral.test.ts
+++ b/ark/type/__tests__/dateLiteral.test.ts
@@ -33,4 +33,9 @@ contextualize(() => {
 	it("invalid date", () => {
 		attest(() => type("d'tuesday'")).throws(writeInvalidDateMessage("tuesday"))
 	})
+
+	it("can morph a Date", () => {
+		const t = type(["Date", "=>", d => d.toISOString()])
+		attest(t.from(new Date(2000, 1))).equals("2000-01-01T00:00:00.000Z")
+	})
 })


### PR DESCRIPTION
Latest arktype version has a regression where using a morph on a `Date` type ends up with:
```
TypeError: Method Date.prototype.toISOString called on incompatible receiver [object Object]
```

I think this is related to deep cloning? PR adds a test to demonstrate.

<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->


