### PR TITLE
fix: accept newlines before an operator

### DIFF
--- a/ark/type/__tests__/string.test.ts
+++ b/ark/type/__tests__/string.test.ts
@@ -12,9 +12,10 @@ contextualize(() => {
 
 	it("ignores whitespace between identifiers/operators", () => {
 		const t = type(`  \n   string  |
-    \tboolean    []   `)
-		attest<string | boolean[]>(t.infer)
-		attest(t.json).equals(type("string|boolean[]").json)
+           number
+    \t|boolean    []   `)
+		attest<string | number | boolean[]>(t.infer)
+		attest(t.json).equals(type("string|number|boolean[]").json)
 	})
 
 	it("errors on bad whitespace", () => {

--- a/ark/type/parser/string/shift/operator/operator.ts
+++ b/ark/type/parser/string/shift/operator/operator.ts
@@ -1,4 +1,4 @@
-import { isKeyOf, type WhiteSpaceToken } from "@ark/util"
+import { isKeyOf, type WhiteSpaceToken, whiteSpaceTokens } from "@ark/util"
 import type { DynamicStateWithRoot } from "../../reduce/dynamic.ts"
 import type { StaticState, state } from "../../reduce/static.ts"
 import { Scanner } from "../scanner.ts"
@@ -23,7 +23,7 @@ export const parseOperator = (s: DynamicStateWithRoot): void => {
 			s.finalize(lookahead)
 		: isKeyOf(lookahead, comparatorStartChars) ? parseBound(s, lookahead)
 		: lookahead === "%" ? parseDivisor(s)
-		: lookahead === " " ? parseOperator(s)
+		: lookahead in whiteSpaceTokens ? parseOperator(s)
 		: s.error(writeUnexpectedCharacterMessage(lookahead))
 	)
 }

--- a/ark/type/parser/string/shift/scanner.ts
+++ b/ark/type/parser/string/shift/scanner.ts
@@ -99,9 +99,9 @@ export class Scanner<lookahead extends string = string> {
 		")": true,
 		"[": true,
 		"%": true,
-		" ": true,
 		",": true,
-		":": true
+		":": true,
+		...whiteSpaceTokens
 	} as const
 
 	static finalizingLookaheads = {


### PR DESCRIPTION
Inserting newlines *after* an operator (`a | \n b`), currently works, but placing the newline before it (`a \n | b`) fails, because the dynamic operator parsing code is hardcoded to only skip spaces. (The static parser *did* correctly check for any whitespace here.) In addition, the list of terminating characters needs to include non-space whitespace, otherwise the newlines can end up as part of the parsed type.

<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
