### PR TITLE
fix: avoid reducing some optional object types to base object

### DIFF
--- a/ark/repo/scratch.ts
+++ b/ark/repo/scratch.ts
@@ -1,6 +1,68 @@
-import { scope, type } from "arktype"
+import { type } from "arktype"
 
-const x = ["a", "b", "c"] as const
-const myType = type({
-	"optional?": type("===", ...x)
+// Syntax carried over from 1.0 + TS
+export const currentTsSyntax = type({
+	keyword: "null",
+	stringLiteral: "'TS'",
+	numberLiteral: "5",
+	bigintLiteral: "5n",
+	union: "string|number",
+	intersection: "boolean&true",
+	array: "Date[]",
+	grouping: "(0|1)[]",
+	objectLiteral: {
+		nested: "string",
+		"optional?": "number"
+	},
+	arrayOfObjectLiteral: [
+		{
+			name: "string"
+		},
+		"[]"
+	],
+	tuple: ["number", "number"]
 })
+
+// available syntax new to 2.0
+
+export const upcomingTsSyntax = type({
+	keyof: "keyof object",
+	variadicTuples: ["true", "...", "false[]"],
+	arrayOfObjectLiteral: type({ name: "string" }).array()
+})
+
+// runtime-specific syntax and builtin keywords with great error messages
+
+export const validationSyntax = type({
+	keywords: "string.email | string.uuid | string.creditCard | number.integer", // and many more
+	builtinParsers: "string.date.parse", // parses a Date from a string
+	nativeRegexLiteral: /@arktype\.io/,
+	embeddedRegexLiteral: "string.email & /@arktype\\.io/",
+	divisibility: "number % 10", // a multiple of 10
+	bound: "string.alpha > 10", // an alpha-only string with more than 10 characters
+	range: "1 <= string.email[] < 100", // a list of 1 to 99 emails
+	narrows: ["number", ":", n => n % 2 === 1], // an odd integer
+	morphs: ["string", "=>", parseFloat] // validates a string input then parses it to a number
+})
+
+// root-level expressions
+
+const intersected = type({ value: "string" }, "&", { format: "'bigint'" })
+
+// chained expressions via .or, .and, .narrow, .pipe and much more
+//  (these replace previous helper methods like union and intersection)
+
+const user = type({
+	name: "string",
+	age: "number"
+})
+
+// type is fully introspectable and traversable
+const parseUser = type("string").pipe(s => JSON.parse(s), user)
+
+const maybeMe = parseUser('{ "name": "David" }')
+
+if (maybeMe instanceof type.errors) {
+	// "age must be a number (was missing)"
+	console.log(maybeMe.summary)
+}

--- a/ark/repo/scratch.ts
+++ b/ark/repo/scratch.ts
@@ -1,1 +1,6 @@
-import { scope } from "arktype"
+import { scope, type } from "arktype"
+
+const x = ["a", "b", "c"] as const
+const myType = type({
+	"optional?": type("===", ...x)
+})

--- a/ark/type/__tests__/objectLiteral.test.ts
+++ b/ark/type/__tests__/objectLiteral.test.ts
@@ -59,6 +59,19 @@ contextualize(() => {
 			attest<typeof U.t>(U.inferIn)
 		})
 
+		// https://github.com/arktypeio/arktype/issues/1102
+		it("optional keys in union not reduced to object", () => {
+			const U = type({ b: type({ "a?": "number" }).or("number") })
+			attest(U.expression).snap("{ b: number | { a?: number } }")
+			attest<{
+				b:
+					| {
+							a?: number
+					  }
+					| number
+			}>(U.t)
+		})
+
 		it("symbol key", () => {
 			const s = Symbol()
 			const name = registeredReference(s)

--- a/ark/type/parser/definition.ts
+++ b/ark/type/parser/definition.ts
@@ -66,11 +66,11 @@ export const parseObject = (def: object, ctx: ParseContext): BaseRoot => {
 
 export type inferDefinition<def, $, args> =
 	[def] extends [anyOrNever] ? def
-	: def extends type.cast<infer t> ?
-		// unlike in TS, ArkType object literals are constrained to object
-		// so we use that as the base type inferred when parsing {}
-		ifEmptyObjectLiteral<t, object, t>
-	: def extends ThunkCast<infer t> ? t
+	: def extends type.cast<infer t> | ThunkCast<infer t> ?
+		// {} as a def is handled here since according to TS it extends { " arkInferred"?: t  }.
+		// Unlike in TS however, ArkType object literals are constrained to object
+		// so we use that as the base type inferred when parsing {}.
+		ifEmptyObjectLiteral<def, object, t>
 	: def extends string ? inferString<def, $, args>
 	: def extends array ? inferTuple<def, $, args>
 	: def extends RegExp ? string.matching<string>

--- a/ark/type/parser/definition.ts
+++ b/ark/type/parser/definition.ts
@@ -66,11 +66,12 @@ export const parseObject = (def: object, ctx: ParseContext): BaseRoot => {
 
 export type inferDefinition<def, $, args> =
 	[def] extends [anyOrNever] ? def
-	: def extends type.cast<infer t> | ThunkCast<infer t> ?
+	: def extends type.cast<infer t> ?
 		// {} as a def is handled here since according to TS it extends { " arkInferred"?: t  }.
 		// Unlike in TS however, ArkType object literals are constrained to object
 		// so we use that as the base type inferred when parsing {}.
 		ifEmptyObjectLiteral<def, object, t>
+	: def extends ThunkCast<infer t> ? t
 	: def extends string ? inferString<def, $, args>
 	: def extends array ? inferTuple<def, $, args>
 	: def extends RegExp ? string.matching<string>

--- a/ark/util/generics.ts
+++ b/ark/util/generics.ts
@@ -27,10 +27,8 @@ export type exactMessageOnError<t extends object, u extends object> = {
 
 /** Returns onTrue if the type is exactly `{}` and onFalse otherwise*/
 export type ifEmptyObjectLiteral<t, onTrue = true, onFalse = false> =
-	{} extends t ?
-		keyof t extends never ?
-			onTrue
-		:	onFalse
+	[unknown, t & (null | undefined)] extends [t | null | undefined, never] ?
+		onTrue
 	:	onFalse
 
 export type leftIfEqual<l, r> = [l, r] extends [r, l] ? l : r

--- a/ark/util/generics.ts
+++ b/ark/util/generics.ts
@@ -25,12 +25,6 @@ export type exactMessageOnError<t extends object, u extends object> = {
 	:	ErrorMessage<`'${k & string}' is not a valid key`>
 } & u
 
-/** Returns onTrue if the type is exactly `{}` and onFalse otherwise*/
-export type ifEmptyObjectLiteral<t, onTrue = true, onFalse = false> =
-	[unknown, t & (null | undefined)] extends [t | null | undefined, never] ?
-		onTrue
-	:	onFalse
-
 export type leftIfEqual<l, r> = [l, r] extends [r, l] ? l : r
 
 export type UnknownUnion =

--- a/ark/util/records.ts
+++ b/ark/util/records.ts
@@ -243,6 +243,12 @@ export const omit = <o extends object, keys extends keySetOf<o>>(
 	keys: keys
 ): omit<o, keyof keys & keyof o> => splitByKeys(o, keys)[1] as never
 
+/** Returns onTrue if the type is exactly `{}` and onFalse otherwise*/
+export type ifEmptyObjectLiteral<t, onTrue = true, onFalse = false> =
+	[unknown, t & (null | undefined)] extends [t | null | undefined, never] ?
+		onTrue
+	:	onFalse
+
 export type EmptyObject = Record<PropertyKey, never>
 
 export const isEmptyObject = (o: object): o is EmptyObject =>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
