### PR TITLE
attest: fix typescript-eslint be recognized as typescript

### DIFF
--- a/ark/attest/tsVersioning.ts
+++ b/ark/attest/tsVersioning.ts
@@ -118,7 +118,7 @@ export const findAttestTypeScriptVersions = (): TsVersionData[] => {
 		}
 		for (const alias in dependencies) {
 			if (!alias.startsWith("typescript")) continue
-
+			if (alias.includes("eslint", 10)) continue
 			const path = join(nodeModulesPath, alias)
 			if (!existsSync(path)) {
 				throw Error(


### PR DESCRIPTION
```
Error: TypeScript version typescript-eslint specified in D:\<my project>/package.json must be installed at D:\<my project>/node_modules/typescript-eslint
```