### PR TITLE
Fix runtime negative length error messages

### DIFF
--- a/ark/schema/refinements/range.ts
+++ b/ark/schema/refinements/range.ts
@@ -256,12 +256,12 @@ export type LengthBoundKind = "minLength" | "maxLength" | "exactLength"
 export const writeNonIntegerLengthBoundMessage = (
 	kind: LengthBoundKind,
 	limit: number
-): string => `${kind} bound must be an integer (was ${limit})`
+): string => `${kind} bound must be a positive integer (was ${limit})`
 
 export const writeNegativeLengthBoundMessage = (
 	kind: LengthBoundKind,
 	limit: number
-): string => `${kind} bound must be an integer (was ${limit})`
+): string => `${kind} bound must be a positive integer (was ${limit})`
 
 export const createLengthRuleParser =
 	(kind: LengthBoundKind) =>

--- a/ark/type/__tests__/realWorld.test.ts
+++ b/ark/type/__tests__/realWorld.test.ts
@@ -1,5 +1,5 @@
 import { attest, contextualize } from "@ark/attest"
-import { registeredReference, type ArkErrors } from "@ark/schema"
+import { registeredReference, rootNode, type ArkErrors } from "@ark/schema"
 import { scope, type, type Module } from "arktype"
 import type {
 	AtLeastLength,
@@ -891,5 +891,15 @@ nospace must be matched by ^\\S*$ (was "One space")`)
 		const t = type({ name: "string" }).and("string[]")
 		attest(t).type.toString.snap("Type<{ name: string } & string[], {}>")
 		attest(t.infer).type.toString.snap("{ name: string } & string[]")
+	})
+
+	// https://github.com/arktypeio/arktype/issues/979
+	// https://github.com/arktypeio/arktype/issues/1124
+	it("negative length constraint", () => {
+		attest(() => rootNode({ proto: "Array", minLength: -1 })).throws("ParseError: minLength bound must be a positive integer (was -1)")
+		attest(() => rootNode({ proto: "String", minLength: -1 })).throws("ParseError: minLength bound must be a positive integer (was -1)")
+
+		attest(() => rootNode({ proto: "Array", maxLength: -1 })).throws("ParseError: maxLength bound must be a positive integer (was -1)")
+		attest(() => rootNode({ proto: "String", maxLength: -1 })).throws("ParseError: maxLength bound must be a positive integer (was -1)")
 	})
 })

--- a/ark/type/__tests__/realWorld.test.ts
+++ b/ark/type/__tests__/realWorld.test.ts
@@ -896,10 +896,18 @@ nospace must be matched by ^\\S*$ (was "One space")`)
 	// https://github.com/arktypeio/arktype/issues/979
 	// https://github.com/arktypeio/arktype/issues/1124
 	it("negative length constraint", () => {
-		attest(() => rootNode({ proto: "Array", minLength: -1 })).throws("ParseError: minLength bound must be a positive integer (was -1)")
-		attest(() => rootNode({ proto: "String", minLength: -1 })).throws("ParseError: minLength bound must be a positive integer (was -1)")
+		attest(() => rootNode({ proto: "Array", minLength: -1 })).throws(
+			"ParseError: minLength bound must be a positive integer (was -1)"
+		)
+		attest(() => rootNode({ proto: "String", minLength: -1 })).throws(
+			"ParseError: minLength bound must be a positive integer (was -1)"
+		)
 
-		attest(() => rootNode({ proto: "Array", maxLength: -1 })).throws("ParseError: maxLength bound must be a positive integer (was -1)")
-		attest(() => rootNode({ proto: "String", maxLength: -1 })).throws("ParseError: maxLength bound must be a positive integer (was -1)")
+		attest(() => rootNode({ proto: "Array", maxLength: -1 })).throws(
+			"ParseError: maxLength bound must be a positive integer (was -1)"
+		)
+		attest(() => rootNode({ proto: "String", maxLength: -1 })).throws(
+			"ParseError: maxLength bound must be a positive integer (was -1)"
+		)
 	})
 })


### PR DESCRIPTION
Closes #1124 

I opted to change both `writeNonIntegerLengthBoundMessage` and `writeNegativeLengthBoundMessage`, since both pertain specifically to lengths and so it makes sense for them to both state the length most be a positive integer.

I suppose the two functions could be merged into one since they're both the same, but I assume them being separate is deliberate.


I verify that:
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally
* [x] There are new or updated unit tests validating the change

