### PR TITLE
repo: add envinfo suggestion to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,11 @@ assignees: "ssalbdivad"
 - TypeScript version (5.1+):
 - Other context you think may be relevant (JS flavor, OS, etc.):
 
+<!--
+  For an easy way to generate this information, run
+  `npx envinfo --system --binaries --npmPackages "{arktype,@ark/*,typescript}" --fullTree`
+-->
+
 ### 🧑‍💻 Repro
 
 <!--


### PR DESCRIPTION
Makes it more likely that issue reports have useful environment information 🙂