### PR TITLE
feat: Added string.base64 and string.base64url

### DIFF
--- a/ark/type/__tests__/keywords/string.test.ts
+++ b/ark/type/__tests__/keywords/string.test.ts
@@ -38,10 +38,10 @@ contextualize(() => {
 		attest(b64url("V29yZA==")).snap("V29yZA==")
 		attest(b64url("V29yZA%3D%3D")).snap("V29yZA%3D%3D")
 		attest(b64url("V29.yZA").toString()).equals(
-			'must be base64-encoded (was "V29.yZA")'
+			'must be base64url-encoded (was "V29.yZA")'
 		)
 		attest(b64url("fn5+").toString()).equals(
-			'must be base64-encoded (was "fn5+")'
+			'must be base64url-encoded (was "fn5+")'
 		)
 	})
 

--- a/ark/type/__tests__/keywords/string.test.ts
+++ b/ark/type/__tests__/keywords/string.test.ts
@@ -19,6 +19,34 @@ contextualize(() => {
 			'must be only letters and digits 0-9 (was "abc@123")'
 		)
 	})
+	it("base64", () => {
+		const b64 = type("string.base64")
+		attest(b64("fn5+")).snap("fn5+")
+		attest(b64("V29yZA==")).snap("V29yZA==")
+		attest(b64("V29yZA").toString()).equals(
+			'must be alphanumeric characters and +/ with the correct amount of = padding (was "V29yZA")'
+		)
+		attest(b64("V29.yZA").toString()).equals(
+			'must be alphanumeric characters and +/ with the correct amount of = padding (was "V29.yZA")'
+		)
+		attest(b64("fn5-").toString()).equals(
+			'must be alphanumeric characters and +/ with the correct amount of = padding (was "fn5-")'
+		)
+	})
+
+	it("base64url", () => {
+		const b64url = type("string.base64url")
+		attest(b64url("fn5-")).snap("fn5-")
+		attest(b64url("V29yZA")).snap("V29yZA")
+		attest(b64url("V29yZA==")).snap("V29yZA==")
+		attest(b64url("V29yZA%3D%3D")).snap("V29yZA%3D%3D")
+		attest(b64url("V29.yZA").toString()).equals(
+			'must be alphanumeric characters and _- optionally with the correct amount of = or %3D padding (was "V29.yZA")'
+		)
+		attest(b64url("fn5+").toString()).equals(
+			'must be alphanumeric characters and _- optionally with the correct amount of = or %3D padding (was "fn5+")'
+		)
+	})
 
 	it("digits", () => {
 		const digits = type("string.digits")

--- a/ark/type/__tests__/keywords/string.test.ts
+++ b/ark/type/__tests__/keywords/string.test.ts
@@ -19,32 +19,29 @@ contextualize(() => {
 			'must be only letters and digits 0-9 (was "abc@123")'
 		)
 	})
+
 	it("base64", () => {
 		const b64 = type("string.base64")
 		attest(b64("fn5+")).snap("fn5+")
 		attest(b64("V29yZA==")).snap("V29yZA==")
 		attest(b64("V29yZA").toString()).equals(
-			'must be alphanumeric characters and +/ with the correct amount of = padding (was "V29yZA")'
+			'must be base64-encoded (was "V29yZA")'
 		)
 		attest(b64("V29.yZA").toString()).equals(
-			'must be alphanumeric characters and +/ with the correct amount of = padding (was "V29.yZA")'
+			'must be base64-encoded (was "V29.yZA")'
 		)
-		attest(b64("fn5-").toString()).equals(
-			'must be alphanumeric characters and +/ with the correct amount of = padding (was "fn5-")'
-		)
-	})
+		attest(b64("fn5-").toString()).equals('must be base64-encoded (was "fn5-")')
 
-	it("base64url", () => {
-		const b64url = type("string.base64url")
+		const b64url = type("string.base64.url")
 		attest(b64url("fn5-")).snap("fn5-")
 		attest(b64url("V29yZA")).snap("V29yZA")
 		attest(b64url("V29yZA==")).snap("V29yZA==")
 		attest(b64url("V29yZA%3D%3D")).snap("V29yZA%3D%3D")
 		attest(b64url("V29.yZA").toString()).equals(
-			'must be alphanumeric characters and _- optionally with the correct amount of = or %3D padding (was "V29.yZA")'
+			'must be base64-encoded (was "V29.yZA")'
 		)
 		attest(b64url("fn5+").toString()).equals(
-			'must be alphanumeric characters and _- optionally with the correct amount of = or %3D padding (was "fn5+")'
+			'must be base64-encoded (was "fn5+")'
 		)
 	})
 

--- a/ark/type/keywords/string/base64.ts
+++ b/ark/type/keywords/string/base64.ts
@@ -1,20 +1,34 @@
+import type { Module, Submodule } from "../../module.ts"
 import type { Predicate, of } from "../inference.ts"
+import { arkModule } from "../utils.ts"
 import { regexStringNode } from "./utils.ts"
+
+export const base64 = arkModule({
+	root: regexStringNode(
+		/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/,
+		"base64-encoded"
+	),
+	url: regexStringNode(
+		/^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2}(?:==|%3D%3D)?|[A-Za-z0-9_-]{3}(?:=|%3D)?)?$/,
+		"base64-encoded"
+	)
+})
 
 declare namespace string {
 	export type base64 = of<string, Predicate<"base64">>
-	export type base64url = of<string, Predicate<"base64url">>
+
+	export namespace base64 {
+		export type url = of<string, Predicate<"base64.url">>
+	}
 }
 
-// https://stackoverflow.com/a/475217/1255873
-export const base64 = regexStringNode(
-	/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/,
-	"alphanumeric characters and +/ with the correct amount of = padding"
-)
-export const base64url = regexStringNode(
-	/^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2}(?:==|%3D%3D)?|[A-Za-z0-9_-]{3}(?:=|%3D)?)?$/,
-	"alphanumeric characters and _- optionally with the correct amount of = or %3D padding"
-)
+export declare namespace base64 {
+	export type module = Module<submodule>
 
-export type base64 = string.base64
-export type base64url = string.base64url
+	export type submodule = Submodule<$>
+
+	export type $ = {
+		root: string.base64
+		url: string.base64.url
+	}
+}

--- a/ark/type/keywords/string/base64.ts
+++ b/ark/type/keywords/string/base64.ts
@@ -1,0 +1,20 @@
+import type { Predicate, of } from "../inference.ts"
+import { regexStringNode } from "./utils.ts"
+
+declare namespace string {
+	export type base64 = of<string, Predicate<"base64">>
+	export type base64url = of<string, Predicate<"base64url">>
+}
+
+// https://stackoverflow.com/a/475217/1255873
+export const base64 = regexStringNode(
+	/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/,
+	"alphanumeric characters and +/ with the correct amount of = padding"
+)
+export const base64url = regexStringNode(
+	/^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2}(?:==|%3D%3D)?|[A-Za-z0-9_-]{3}(?:=|%3D)?)?$/,
+	"alphanumeric characters and _- optionally with the correct amount of = or %3D padding"
+)
+
+export type base64 = string.base64
+export type base64url = string.base64url

--- a/ark/type/keywords/string/base64.ts
+++ b/ark/type/keywords/string/base64.ts
@@ -10,7 +10,7 @@ export const base64 = arkModule({
 	),
 	url: regexStringNode(
 		/^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2}(?:==|%3D%3D)?|[A-Za-z0-9_-]{3}(?:=|%3D)?)?$/,
-		"base64-encoded"
+		"base64url-encoded"
 	)
 })
 

--- a/ark/type/keywords/string/string.ts
+++ b/ark/type/keywords/string/string.ts
@@ -16,7 +16,7 @@ import type {
 import { arkModule } from "../utils.ts"
 import { alpha } from "./alpha.ts"
 import { alphanumeric } from "./alphanumeric.ts"
-import { base64, base64url } from "./base64.ts"
+import { base64 } from "./base64.ts"
 import { capitalize } from "./capitalize.ts"
 import { creditCard } from "./creditCard.ts"
 import { stringDate } from "./date.ts"
@@ -41,7 +41,6 @@ export const string = arkModule({
 	alpha,
 	alphanumeric,
 	base64,
-	base64url,
 	digits,
 	semver,
 	ip,
@@ -105,8 +104,7 @@ export declare namespace string {
 		root: string
 		alpha: alpha
 		alphanumeric: alphanumeric
-		base64: base64
-		base64url: base64url
+		base64: base64.submodule
 		digits: digits
 		numeric: stringNumeric.submodule
 		integer: stringInteger.submodule

--- a/ark/type/keywords/string/string.ts
+++ b/ark/type/keywords/string/string.ts
@@ -16,6 +16,7 @@ import type {
 import { arkModule } from "../utils.ts"
 import { alpha } from "./alpha.ts"
 import { alphanumeric } from "./alphanumeric.ts"
+import { base64, base64url } from "./base64.ts"
 import { capitalize } from "./capitalize.ts"
 import { creditCard } from "./creditCard.ts"
 import { stringDate } from "./date.ts"
@@ -39,6 +40,8 @@ export const string = arkModule({
 	integer,
 	alpha,
 	alphanumeric,
+	base64,
+	base64url,
 	digits,
 	semver,
 	ip,
@@ -102,6 +105,8 @@ export declare namespace string {
 		root: string
 		alpha: alpha
 		alphanumeric: alphanumeric
+		base64: base64
+		base64url: base64url
 		digits: digits
 		numeric: stringNumeric.submodule
 		integer: stringInteger.submodule


### PR DESCRIPTION
This PR adds simple regex-based keywords for `string.base64` and `string.base64url`.

* [X] Code is up-to-date with the `main` branch
* [X] You've successfully run `pnpm prChecks` locally
  * The `registry` test currently fails due to a bug in the main repo for `@ark/util`. I've confirmed that fixing this locally causes all checks and tests to pass.
* [X] There are new or updated unit tests validating the change

Notes:

The regular expression used does not allow for whitespace as it isn't allowed by the [Base64 specification](https://datatracker.ietf.org/doc/html/rfc4648). However, many common Base64 implementations will implicitly ignore whitespace in the string, including `atob` and `Buffer.from(..., 'base64')`. Should this implementation strictly adhere to the specification or allow "incorrect" Base64 strings with whitespace in them?