### PR TITLE
DRAFT: Improve onboarding with documentation guides

### DIFF
--- a/ark/docs/astro.config.js
+++ b/ark/docs/astro.config.js
@@ -44,6 +44,12 @@ export default defineConfig({
 					}
 				},
 				{
+					label: "Guides",
+					autogenerate: {
+						directory: "guides"
+					},
+				},
+				{
 					label: "Keywords",
 					collapsed: true,
 					items: [

--- a/ark/docs/package.json
+++ b/ark/docs/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@ark/fs": "workspace:*",
 		"@ark/util": "workspace:*",
+		"@ark/schema": "workspace:*",
 		"@astrojs/check": "0.9.4",
 		"@astrojs/react": "3.6.2",
 		"@astrojs/starlight": "0.28.3",

--- a/ark/docs/src/content/docs/guides/basics.mdx
+++ b/ark/docs/src/content/docs/guides/basics.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Primitives & validation
 
-The `type` object is the entrypoint for your validation schemas.
+The `type` object is the entrypoint for your validation schemas.  
 Let's start with a very simple type :
 
 ```ts
@@ -15,7 +15,8 @@ import { type } from "arktype"
 const someString = type('string')
 ```
 
-`type` accepts a variety of values, including `string`, `number`, `symbol`, actual RegEx or literals like `"foobar"`.  Maybe you have noticed that our literal string is wrapped into double quoted. That is because Arktype interpret strings the same way TypeScript interpret types.
+`type` accepts a variety of values, including `string`, `number`, `symbol`, actual RegEx or literals like `"foobar"`.  
+Maybe you have noticed that our literal string is wrapped into double quoted. That is because Arktype interpret strings the same way TypeScript interpret types.
 
 Let's validate some data !
 
@@ -31,13 +32,13 @@ const invalid = someString(1)        // ❌ - ArkErrors
 const str = someString.assert('kaboom?')
 ```
 
-When a value doesn't successfully pass the validation, an instance of ArkErrors is returned instead of the value.  
+When a value doesn't successfully pass the validation, an instance of `ArkErrors` is returned instead of the value.  
 More on errors later.
 
 ## Unions & intersections
 
 There are several ways to create a union or an intersection with Arktype.  
-We'll show case unions, but you can use `&` and `.and()` to create intersections.
+We will show case unions, but you can use `&` and `.and()` to create intersections.
 
 ```ts
 import { type } from "arktype"
@@ -71,7 +72,7 @@ const method4 = type([
 ]]])
 ```
 
-Because `type` accepts a tuple as argument, and because each element of the tuple is interpreted as an instance of `type`, you can use nested tuples to create more complex types in one go.
+Because `type` also accepts a tuple as an argument, and because each element of the tuple is interpreted as an instance of `type`, you can use nested tuples to create more complex types in one go.
 
 ## Objects
 
@@ -92,7 +93,7 @@ Again, every value is interpreted as an instance of `type`, so you don't need to
 
 :::note
 The optional marker only allow the property to be missing, not to be `undefined`.  
-To allow both, use `undefined | string?`.
+To allow both, use `{ 'birthdate?': 'undefined | string' }`.
 :::
 
 ### Records
@@ -164,3 +165,5 @@ const schema = type(['string', 'number'])
 const schema3 = type(["string", userSchema])
 const schema2 = type(["string", "...", "number[]"])
 ```
+
+Have you noticed the `"..."` operator to create the variable number of elements in the tuple ?

--- a/ark/docs/src/content/docs/guides/basics.mdx
+++ b/ark/docs/src/content/docs/guides/basics.mdx
@@ -1,0 +1,166 @@
+---
+title: The basics
+sidebar:
+  order: 1
+---
+
+## Primitives & validation
+
+The `type` object is the entrypoint for your validation schemas.
+Let's start with a very simple type :
+
+```ts
+import { type } from "arktype"
+
+const someString = type('string')
+```
+
+`type` accepts a variety of values, including `string`, `number`, `symbol`, actual RegEx or literals like `"foobar"`.  Maybe you have noticed that our literal string is wrapped into double quoted. That is because Arktype interpret strings the same way TypeScript interpret types.
+
+Let's validate some data !
+
+```ts
+import { type } from "arktype"
+const someString = type('string')
+
+// ---cut-before---
+const valid = someString('Hello 👋') // ✅ - Hello 👋
+const invalid = someString(1)        // ❌ - ArkErrors
+
+// The following will throw if the data is invalid, instead of returning ArkErrors.
+const str = someString.assert('kaboom?')
+```
+
+When a value doesn't successfully pass the validation, an instance of ArkErrors is returned instead of the value.  
+More on errors later.
+
+## Unions & intersections
+
+There are several ways to create a union or an intersection with Arktype.  
+We'll show case unions, but you can use `&` and `.and()` to create intersections.
+
+```ts
+import { type } from "arktype"
+
+const schema = type('string');
+const schema2 = type('number');
+
+// ---cut-before---
+const method1 = type('string | number')
+const method2 = type('string').or('number')
+const method3 = schema.or(schema2)
+```
+
+Notice that you don't have to pass an instance of `type` to `.or()`, the argument is already interpreted as such.
+If you want to create a larger union, you can use nested tuples :
+
+```ts
+// @errors: 2304
+import { type } from "arktype"
+
+const schema1 = type({ foo: 'string' });
+const schema2 = type({ bar: 'string' });
+const schema3 = type({ bazz: 'string' });
+const schema4 = type({ yolo: '"Hell yeah!"'});
+// ---cut-before---
+
+const method4 = type([
+	schema1, '|', [
+	schema2, '|', [
+	schema3, '|', schema4
+]]])
+```
+
+Because `type` accepts a tuple as argument, and because each element of the tuple is interpreted as an instance of `type`, you can use nested tuples to create more complex types in one go.
+
+## Objects
+
+Creating an object with Arktype is very simple :
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const userSchema = type({
+	username: 'string',
+	'birthdate?': 'string',           // We make the property as optional with "?" 
+	'connectionCount?': 'number = 1', // We set the default value to 1 
+})
+```
+
+Again, every value is interpreted as an instance of `type`, so you don't need to repeat yourself.
+
+:::note
+The optional marker only allow the property to be missing, not to be `undefined`.  
+To allow both, use `undefined | string?`.
+:::
+
+### Records
+
+If you want to create records, `type` has a utility property that can help you with that :
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const teamSchema = type({
+	name: 'string',
+	memberships: type.Record(
+		/user__[a-z0-9]/,
+		{ jointedAt: 'number', leftAt: 'number?' }
+	)
+})
+```
+
+### Merging schemas
+
+Quite often, the data you expect will share some properties with other schemas.
+Instead of repeating yourself, you can re-use a schema in others. Hover `orderReceivedEventSchema` to discover the merged type.
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const baseEventSchema = type({
+	type: '"orderReceived" | "orderAccepted"',
+	createdBy: 'string',
+	createdAt: 'number',
+})
+
+const orderReceivedEventSchema = baseEventSchema.merge({
+	type: '"orderReceived"',
+	payload: {
+		orderId: 'string',
+	}
+})
+```
+
+As you can see by hovering `orderReceivedEventSchema`, the overlapping property defined in the merged object overwrites the one of the base object.
+
+## Arrays & tuples
+
+You can create an array in several ways :
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const schema = type('string[]')
+const schema2 = type('string').array()
+const schema3 = type.Array('string')
+```
+
+Creating tuples is not more difficult and follow the same rules we've described before :
+
+```ts
+import { type } from "arktype"
+
+const userSchema = type({
+	username: 'string'
+})
+
+// ---cut-before---
+const schema = type(['string', 'number'])
+const schema3 = type(["string", userSchema])
+const schema2 = type(["string", "...", "number[]"])
+```

--- a/ark/docs/src/content/docs/guides/constraints.mdx
+++ b/ark/docs/src/content/docs/guides/constraints.mdx
@@ -31,46 +31,6 @@ const email = type('string.email')
 const date =  type('string.date.iso')
 ```
 
-### Custom constraints
-Arktype offer some transformation mechanisms. You can apply a constraint before or after the transformations.
-
-
-#### `satisfying`
-
-Use `satisfying` will be apply before any transformation logic.
-
-```ts
-import { type } from "arktype"
-
-// ---cut-before---
-type UserId = `user__${string}`;
-
-const userId = type('string').satisfying((v, ctx): v is UserId => {
-	if (v.startsWith('user__')) {
-		return true
-	}
-	
-	return ctx.mustBe('a UserId')
-});
-```
-
-#### `narrow`
-
-Use `narrow` will be apply after all transformation logic.
-
-```ts
-import { type } from "arktype"
-
-// ---cut-before---
-const stepNumber = type('string.numeric.parse').narrow((v, ctx) => {
-	if (v > 0 && v < 4) {
-		return true
-	}
-	
-	return ctx.mustBe('a step number');
-});
-```
-
 ## Number
 
 ### Range constraints
@@ -92,4 +52,44 @@ import { type } from "arktype"
 const integer =     type('number.integer') 
 const safeInteger = type('number.safe') // number <= Number.MAX_SAFE_INTEGER
 const epoch =       type('number.epoch')
+```
+
+## Custom constraints
+Arktype offers some transformation mechanisms. You can apply constraints before or after the transformations.
+
+
+### `satisfying`
+
+Use `satisfying` and the constraints will be apply before any transformation logic.
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+type UserId = `user__${string}`;
+
+const userId = type('string').satisfying((v, ctx): v is UserId => {
+	if (v.startsWith('user__')) {
+		return true
+	}
+	
+	return ctx.mustBe('a UserId')
+});
+```
+
+### `narrow`
+
+Use `narrow` and the constraints will be apply after all transformation logic.
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const stepNumber = type('string.numeric.parse').narrow((v, ctx) => {
+	if (v > 0 && v < 4) {
+		return true
+	}
+	
+	return ctx.mustBe('a step number');
+});
 ```

--- a/ark/docs/src/content/docs/guides/constraints.mdx
+++ b/ark/docs/src/content/docs/guides/constraints.mdx
@@ -1,0 +1,95 @@
+---
+title: Adding constraints
+sidebar:
+  order: 2
+---
+
+## String
+
+Let's dive right into it with some classics :
+
+### Length constraints
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const min4 =      type('string >= 4') 
+const max10 =     type('string <= 10')
+const min4max10 = type('string >= 4 & string <= 10')
+```
+
+### Shape constraints
+
+There are many constraints built-in, just type `string.` to discover them all.
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const regex = type(/[a-z0-9]{4,10}/) 
+const email = type('string.email')
+const date =  type('string.date.iso')
+```
+
+### Custom constraints
+Arktype offer some transformation mechanisms. You can apply a constraint before or after the transformations.
+
+
+#### `satisfying`
+
+Use `satisfying` will be apply before any transformation logic.
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+type UserId = `user__${string}`;
+
+const userId = type('string').satisfying((v, ctx): v is UserId => {
+	if (v.startsWith('user__')) {
+		return true
+	}
+	
+	return ctx.mustBe('a UserId')
+});
+```
+
+#### `narrow`
+
+Use `narrow` will be apply after all transformation logic.
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const stepNumber = type('string.numeric.parse').narrow((v, ctx) => {
+	if (v > 0 && v < 4) {
+		return true
+	}
+	
+	return ctx.mustBe('a step number');
+});
+```
+
+## Number
+
+### Range constraints
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const min4 =      type('number >= 4') 
+const max10 =     type('number <= 10')
+const min4max10 = type('number >= 4 & number <= 10')
+```
+
+### Other constraints
+
+```ts
+import { type } from "arktype"
+
+// ---cut-before---
+const integer =     type('number.integer') 
+const safeInteger = type('number.safe') // number <= Number.MAX_SAFE_INTEGER
+const epoch =       type('number.epoch')
+```

--- a/ark/docs/src/content/docs/guides/generics.mdx
+++ b/ark/docs/src/content/docs/guides/generics.mdx
@@ -5,7 +5,7 @@ sidebar:
 ---
 
 Ever wanted to create a function that takes a schema and return another schema ?  
-Arktype call them `generics`, and they are exactly what you think they are.
+Arktype calls them `generics`, and they are exactly what you think they are.
 
 ## Single argument
 
@@ -37,6 +37,7 @@ const orderCreatedEvent = eventType({
 	numberOfItems: 'number > 0'
 })
 ```
+Hover `orderCreatedEvent` to discover your new type !  
 
 You can also add a constraint, just you like you would do it in TypeScript with `<Payload extends Record<string, unknown>>`.
 
@@ -53,9 +54,10 @@ const eventType = generic(['Type', 'string'], 'Payload')({
 });
 ```
 
-First thing to notice, there is no bracket using this syntax.  
+First thing to notice, there is no angle bracket with this syntax.  
+
 Second, if you want to add a constraint to your generic, you need to pass a tuple.  
-Here, `Type` must extends `string`, and because `Payload` is given as is, there is no constraint on it this time.
+Here, `Type` must extends `string`, and because `Payload` is given as is, we have set no constraint on it.
 
 ## Going further
 
@@ -77,7 +79,7 @@ const eventType = genericParser({
 
 The argument given to `genericParser` is, itself, a type definition.  
 This means you can use all available syntaxes to create your dynamic type with generics.  
-For example, if you want to merge types, you can do it :
+For example, if you want to merge types, you can use the tuple syntax :
 
 ```ts
 import { generic, type } from "arktype"
@@ -85,12 +87,20 @@ import { generic, type } from "arktype"
 const genericParser = generic(['CreatedBy', 'string'], 'Schema');
 
 // ---cut-before---
+// We prepare our generic type
 const audit = type({
 	createdBy: 'string',
-	createdAt: 'number.epoch'
+	createdAt: 'number.epoch',
 })
 
 const withAudit = type('<Schema>', [audit, '&', 'Schema']);
 
-const bookWithAudit = withAudit({ title: 'string' });
+// Some app type
+const book = type({ 
+	title: 'string', 
+	authors: 'string[]', 
+})
+
+// We use our generic type to create a new type 🪄
+const bookWithAudit = withAudit(book);
 ```

--- a/ark/docs/src/content/docs/guides/generics.mdx
+++ b/ark/docs/src/content/docs/guides/generics.mdx
@@ -1,0 +1,96 @@
+---
+title: Dynamic types
+sidebar:
+  order: 4
+---
+
+Ever wanted to create a function that takes a schema and return another schema ?  
+Arktype call them `generics`, and they are exactly what you think they are.
+
+## Single argument
+
+Let's start simple with a dynamic `payload` property :
+```ts
+import { type } from "arktype"
+
+const eventType = type('<Payload>', { 
+	type: 'string',
+	createdAt: 'number.epoch',
+	payload: 'Payload'
+})
+```
+
+Now you can use `eventType` to create a new type :
+
+```ts
+import { type } from "arktype"
+
+const eventType = type('<Payload>', { 
+	type: 'string',
+	createdAt: 'number.epoch',
+	payload: 'Payload'
+})
+
+// ---cut-before---
+const orderCreatedEvent = eventType({
+	orderId: 'string',
+	numberOfItems: 'number > 0'
+})
+```
+
+You can also add a constraint, just you like you would do it in TypeScript with `<Payload extends Record<string, unknown>>`.
+
+## Multiple arguments
+If you want to have more parameters, you need a new syntax :
+
+```ts
+import { generic } from "arktype"
+
+const eventType = generic(['Type', 'string'], 'Payload')({
+	type: 'Type',
+	createdAt: 'number.epoch',
+	payload: 'Payload'
+});
+```
+
+First thing to notice, there is no bracket using this syntax.  
+Second, if you want to add a constraint to your generic, you need to pass a tuple.  
+Here, `Type` must extends `string`, and because `Payload` is given as is, there is no constraint on it this time.
+
+## Going further
+
+Perhaps you have noticed that the construction of the dynamic type is done in two steps.
+
+```ts
+import { generic } from "arktype"
+
+// We create a function that will accept a type that have access to the generic arguments.
+const genericParser = generic(['Type', 'string'], 'Payload');
+
+// We create a function that will receive the arguments and return a type.
+const eventType = genericParser({
+	type: 'Type',
+	createdAt: 'number.epoch',
+	payload: 'Payload'
+});
+```
+
+The argument given to `genericParser` is, itself, a type definition.  
+This means you can use all available syntaxes to create your dynamic type with generics.  
+For example, if you want to merge types, you can do it :
+
+```ts
+import { generic, type } from "arktype"
+
+const genericParser = generic(['CreatedBy', 'string'], 'Schema');
+
+// ---cut-before---
+const audit = type({
+	createdBy: 'string',
+	createdAt: 'number.epoch'
+})
+
+const withAudit = type('<Schema>', [audit, '&', 'Schema']);
+
+const bookWithAudit = withAudit({ title: 'string' });
+```

--- a/ark/docs/src/content/docs/guides/scopes.mdx
+++ b/ark/docs/src/content/docs/guides/scopes.mdx
@@ -33,14 +33,14 @@ const userScope = scope({
 });
 ```
 
-You may have discovered a new syntax to define records or object with index signature.  
-We can't use `type.Record` when using a type defined in the very scope we are creating.
+You may have discovered a new syntax to define records or _object with index signature_ ⚡️.  
 
+This new syntax is necessary because we can't use `type.Record` with a type defined in the very scope we are creating.  
 By using the new syntax, we were able to use the type `UserId` defined in the same scope.
 
 ## Building around scopes
 
-Once you have defined a scope, its type are tied to it.  
+Once you have defined a scope, its types are tied to it.  
 But you probably want to use them in other places. To do that, export them :
 ```ts
 import { PredicateCast } from "@ark/schema" 

--- a/ark/docs/src/content/docs/guides/scopes.mdx
+++ b/ark/docs/src/content/docs/guides/scopes.mdx
@@ -1,0 +1,76 @@
+---
+title: Write your own literal type
+sidebar:
+  order: 3
+---
+
+Do you want to write types like `type('UserId[]')` ?   
+Arktype offers the concept of `Scope`, and they are for you.
+
+## Introduction
+
+When you create a type with `type('string')`, `string` is actually the name of a type in something called a `Scope`.  
+The `type` object uses the default scope, so you can use all built-in types immediately.
+
+```ts
+import type { PredicateCast } from "@ark/schema" 
+import { scope, type } from "arktype"
+
+type UserId = `user__${string}`;
+
+const isUserId: PredicateCast<string, UserId> = (v, ctx): v is UserId => {
+	if (v.startsWith('user__')) {
+		return true
+	}
+
+	return ctx.mustBe('a UserId')
+}
+
+// ---cut-before---
+const userScope = scope({
+	UserId: type('string').satisfying(isUserId),
+	memberships: { '[UserId]': { joinedAt: 'number.epoch' }}
+});
+```
+
+You may have discovered a new syntax to define records or object with index signature.  
+We can't use `type.Record` when using a type defined in the very scope we are creating.
+
+By using the new syntax, we were able to use the type `UserId` defined in the same scope.
+
+## Building around scopes
+
+Once you have defined a scope, its type are tied to it.  
+But you probably want to use them in other places. To do that, export them :
+```ts
+import { PredicateCast } from "@ark/schema" 
+import { scope, type } from "arktype"
+
+type UserId = `user__${string}`;
+
+const isUserId: PredicateCast<string, UserId> = (v, ctx): v is UserId => {
+	if (v.startsWith('user__')) {
+		return true
+	}
+
+	return ctx.mustBe('a UserId')
+}
+
+const userScope = scope({
+	UserId: type('string').satisfying(isUserId),
+	memberships: { '[UserId]': { joinedAt: 'number.epoch' }}
+});
+
+declare const data: unknown;
+
+// ---cut-before---
+export const userTypes = userScope.export();
+
+// Building another scope
+const teamScope = scope({
+	members: userTypes.UserId.array()
+})
+
+// ...or validating some data
+const memberships = userTypes.memberships.assert(data);
+```


### PR DESCRIPTION
After discovering Arktype a few weeks ago, I struggled to migrate from `zod` to `arktype`.
I felt the documentation lacked some walkthrough to discover the concepts from the arktype perspective.

To me, there are two main reasons for that : 

1. Some features are simply not documented
2. The menu items are named after the concept name and not the usage

Many built-in types have just no documentation as well as many utility functions like `type.Record` which don't have JSDoc either.

Take the menu items `Keyword > this` for example.
When I'm searching into the documentation, I will not look for `this`, simply because I can't tell that's the solution to my problem.
If the item was named `Recursive type`, and then I was introduced to the `this` keyword, the discovery would have been more natural.

So I drafted this PR, introducing `guides`.

<img width="277" alt="Screenshot 2024-11-19 at 14 52 54" src="https://github.com/user-attachments/assets/39572360-336d-4a26-b0f8-58b66bc055f7">

The `Guides` section aims to walkthrough user cases, rather providing an exhaustive API reference. 

In its current state, I feel like all the documentation is really an API reference, with the exception of a few pages.

Going further, we could merge the other menu items into three big pages : 

1. `Syntaxes` where one can read all the available syntaxes and ways to build a type.
2. `Built-in types` that contains all the built-in types and transformations available.
3. `API Reference` that describe all functions available within `type`.

So, what to do with this PR ?

If you think I'm going the right direction, let me know in the comment and I will work on the next steps as I described them.

As for now, the guides pages overlap with existing pages, so I don't think it's ok to merge this PR as it is.
Given you validate the goal, we could merge this PR once I've written a guide page on transformations.
A future PR can proceed with the merging of the menu items and the redaction of the exhaustive reference pages.