### PR TITLE
Fix broken link to string literals docs page

### DIFF
--- a/ark/docs/astro.config.js
+++ b/ark/docs/astro.config.js
@@ -56,7 +56,7 @@ export default defineConfig({
 									label: "keywords",
 									link: "/primitives#string/keywords"
 								},
-								{ label: "literals", link: "/string#literals" },
+								{ label: "literals", link: "/primitives#string/literals" },
 								{
 									label: "patterns",
 									link: "/primitives#string/patterns"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

The sidebar currently redirects to https://arktype.io/string#literals, however the correct link is https://arktype.io/primitives/#string/literals
