### PR TITLE
Clarify date string literals being passed to Date in objects.mdx

### DIFF
--- a/ark/docs/src/content/docs/objects.mdx
+++ b/ark/docs/src/content/docs/objects.mdx
@@ -512,7 +512,7 @@ const myTuple = type(["...", type.number.array(), type.boolean, type.string])
 <a name="dates/literals" />
 ##### literals
 
-Date literals represent a Date instance with an exact value.
+Date literals represent a Date instance with an exact value. Date literal string are not validated statically, just passed to Date constructor at runtime.
 
 They're primarily useful in ranges.
 

--- a/ark/docs/src/content/docs/objects.mdx
+++ b/ark/docs/src/content/docs/objects.mdx
@@ -512,9 +512,13 @@ const myTuple = type(["...", type.number.array(), type.boolean, type.string])
 <a name="dates/literals" />
 ##### literals
 
-Date literals represent a Date instance with an exact value. Date literal string are not validated statically, just passed to Date constructor at runtime.
+Date literals represent a Date instance with an exact value.
 
-They're primarily useful in ranges.
+It is recommended that the date literal string content be in [JavaScript date-time format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format).
+The value of a Date literal is determined by constructing a `new Date(dateLiteralContents)`, though, so [any string format accepted by `Date()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#datestring) is acceptable.
+A Date literal that results in an invalid Date will throw a ParseError.
+
+Date literals are primarily useful in ranges.
 
 ```ts
 const literals = type({


### PR DESCRIPTION
Based on this comment: https://github.com/arktypeio/arktype/issues/518#issue-1414353250

Added because I found the lack of a standard date format in the examples confusing, forgetting that this is just how Date works.

<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
