### PR TITLE
docs: fix scope example import

### DIFF
--- a/ark/docs/content/docs/scopes/index.mdx
+++ b/ark/docs/content/docs/scopes/index.mdx
@@ -17,7 +17,7 @@ To define a scope, you may either `import { scope } from "arktype"` or use `type
 A scope is specified as an object literal mapping names to definitions.
 
 ```ts
-import { type } from "arktype"
+import { scope } from "arktype"
 
 const coolScope = scope({
 	// keywords are still available in your scope


### PR DESCRIPTION
The scope example in the docs imported `type` instead of `scope`.
