### PR TITLE
docs: add main page title

### DIFF
--- a/ark/docs/app/(home)/layout.tsx
+++ b/ark/docs/app/(home)/layout.tsx
@@ -18,6 +18,7 @@ export default ({ children }: LayoutProps): React.ReactElement => (
 			children: <FloatYourBoat kind="header" />
 		}}
 	>
+		<title>ArkType</title>
 		{children}
 	</HomeLayout>
 )


### PR DESCRIPTION
Hello, title page is missing on the main page and as such my browser window is simply titled `Mozilla Firefox`.  
This change adds a title tag in HomeLayout which sets it only for the main page. Documentation page titles are unchanged.