### PR TITLE
preserve jsdoc and navigation for homomorphic keys

### DIFF
--- a/ark/attest/CHANGELOG.md
+++ b/ark/attest/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 NOTE: This changelog is incomplete, but will include notable attest-specific changes (many updates consist almost entirely of bumped `arktype` versions for assertions).
 
+## 0.44.0
+
+Support assertions for JSDoc contents associated with an `attest`ed value
+
+```ts
+const t = type({
+	/** FOO */
+	foo: "string"
+})
+
+const out = t.assert({ foo: "foo" })
+
+// match or snapshot expected jsdoc associated with the value passed to attest
+attest(out.foo).jsdoc.snap("FOO")
+```
+
 ## 0.41.0
 
 ### Bail early for obviously incorrect `equals` comparisons

--- a/ark/attest/README.md
+++ b/ark/attest/README.md
@@ -112,6 +112,18 @@ describe("attest features", () => {
 		attest({ "f": "🐐" } as Legends).completions({ "f": ["faker"] })
 	})
 
+	it("jsdoc snapshotting", () => {
+		// match or snapshot expected jsdoc associated with the value passed to attest
+		const t = type({
+			/** FOO */
+			foo: "string"
+		})
+
+		const out = t.assert({ foo: "foo" })
+
+		attest(out.foo).jsdoc.snap("FOO")
+	})
+
 	it("integrate runtime logic with type assertions", () => {
 		const arrayOf = type("<t>", "t[]")
 		const numericArray = arrayOf("number | bigint")

--- a/ark/attest/__tests__/assertions.test.ts
+++ b/ark/attest/__tests__/assertions.test.ts
@@ -180,4 +180,25 @@ Actual: string`)
 Expected: {"a":"five"}
 Actual: ArkErrors`)
 	})
+
+	it("jsdoc ", () => {
+		type O = {
+			/** FOO */
+			foo: string
+			bar: number
+		}
+
+		const o: O = {
+			foo: "foo",
+			bar: 5
+		}
+
+		attest(o.foo).jsdoc.equals("FOO")
+
+		assert.throws(
+			() => attest(o.bar).jsdoc.equals("BAR"),
+			assert.AssertionError,
+			"BAR"
+		)
+	})
 })

--- a/ark/attest/assert/chainableAssertions.ts
+++ b/ark/attest/assert/chainableAssertions.ts
@@ -234,6 +234,16 @@ export class ChainableAssertions implements AssertionRecord {
 		return this.snap
 	}
 
+	get jsdoc(): any {
+		if (this.ctx.cfg.skipTypes) return chainableNoOpProxy
+
+		this.ctx.versionableActual = new TypeAssertionMapping(data => ({
+			actual: formatTypeString(data.jsdoc ?? "")
+		}))
+		this.ctx.allowRegex = true
+		return this.immediateOrChained()
+	}
+
 	get type(): any {
 		if (this.ctx.cfg.skipTypes) return chainableNoOpProxy
 
@@ -351,6 +361,7 @@ export type comparableValueAssertion<expected, kind extends AssertionKind> = {
 	instanceOf: (constructor: Constructor) => nextAssertions<kind>
 	is: (value: expected) => nextAssertions<kind>
 	completions: CompletionsSnap
+	jsdoc: comparableValueAssertion<string, kind>
 	satisfies: <const def>(
 		def: type.validate<def> &
 			validateExpectedOverlaps<expected, type.infer.In<def>>

--- a/ark/attest/cache/utils.ts
+++ b/ark/attest/cache/utils.ts
@@ -11,10 +11,7 @@ import {
 	getTsConfigInfoOrThrow,
 	getTsLibFiles
 } from "./ts.ts"
-import type {
-	AssertionsByFile,
-	LinePositionRange
-} from "./writeAssertionCache.ts"
+import type { LinePositionRange } from "./writeAssertionCache.ts"
 
 export const getCallLocationFromCallExpression = (
 	callExpression: ts.CallExpression
@@ -41,15 +38,16 @@ export const getCallLocationFromCallExpression = (
 	return location
 }
 
+/**
+ * Processes inline instantiations from an attest call
+ * Preserves any JSDoc comments that are associated with the original expression
+ */
 export const gatherInlineInstantiationData = (
 	file: ts.SourceFile,
-	fileAssertions: AssertionsByFile,
-	attestAliasInstantiationMethodCalls: string[]
+	assertionsByFile: Record<string, any[]>,
+	instantiationMethodCalls: string[]
 ): void => {
-	const expressions = getCallExpressionsByName(
-		file,
-		attestAliasInstantiationMethodCalls
-	)
+	const expressions = getCallExpressionsByName(file, instantiationMethodCalls)
 	if (!expressions.length) return
 
 	const enclosingFunctions = expressions.map(expression => {
@@ -81,8 +79,8 @@ ${enclosingFunction.ancestor.getText()}`
 			count: getInstantiationsContributedByNode(file, body)
 		}
 	})
-	const assertions = fileAssertions[getFileKey(file.fileName)] ?? []
-	fileAssertions[getFileKey(file.fileName)] = [
+	const assertions = assertionsByFile[getFileKey(file.fileName)] ?? []
+	assertionsByFile[getFileKey(file.fileName)] = [
 		...assertions,
 		...instantiationInfo
 	]

--- a/ark/attest/package.json
+++ b/ark/attest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/attest",
-	"version": "0.43.4",
+	"version": "0.44.0",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/fs/package.json
+++ b/ark/fs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/fs",
-	"version": "0.43.4",
+	"version": "0.44.0",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/repo/scratch.ts
+++ b/ark/repo/scratch.ts
@@ -1,12 +1,13 @@
 import { type } from "arktype"
 
-const types = type.module(
-	{
-		foo: {
-			test: "string = 'test'"
-		}
-	},
-	{ jitless: true }
-)
+const t = type({
+	/** FOO */
+	foo: "string",
+	/** BAR */
+	bar: "number?"
+})
 
-types.foo({}) //?
+const out = t.assert({ foo: "foo" })
+
+out.foo
+out.bar

--- a/ark/schema/package.json
+++ b/ark/schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/schema",
-	"version": "0.43.4",
+	"version": "0.44.0",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -1,5 +1,31 @@
 # arktype
 
+## 2.1.5
+
+#### Fix JSDoc and go-to definition for unparsed keys
+
+Addresses #1294
+
+```ts
+const t = type({
+	/** FOO */
+	foo: "string",
+	/** BAR */
+	bar: "number?"
+})
+
+const out = t.assert({ foo: "foo" })
+
+// go-to definition will now navigate to the foo prop from the type call
+// hovering foo now displays "FOO"
+console.log(out.foo)
+
+// go-to definition will now navigate to the bar prop from the type call
+// hovering bar now displays "BAR"
+// (the ? must be in the value for this to work)
+console.log(out.bar)
+```
+
 ## 2.1.4
 
 Static hermes compatibility (#1027)

--- a/ark/type/__tests__/objects/namedKeys.test.ts
+++ b/ark/type/__tests__/objects/namedKeys.test.ts
@@ -235,4 +235,26 @@ contextualize(() => {
 			"bool_value must be a string (was boolean)"
 		)
 	})
+
+	it("required key homomorphic", () => {
+		const t = type({
+			/** FOO */
+			foo: "string"
+		})
+
+		const out = t.assert({ foo: "foo" })
+
+		attest(out.foo).jsdoc.snap("FOO")
+	})
+
+	it("optional value homomorphic", () => {
+		const t = type({
+			/** BAR */
+			bar: "number?"
+		})
+
+		const out = t.assert({})
+
+		attest(out.bar).jsdoc.snap("BAR")
+	})
 })

--- a/ark/type/package.json
+++ b/ark/type/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arktype",
 	"description": "Optimized runtime validation for TypeScript syntax",
-	"version": "2.1.4",
+	"version": "2.1.5",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/ark/util/package.json
+++ b/ark/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/util",
-	"version": "0.43.4",
+	"version": "0.44.0",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/util/registry.ts
+++ b/ark/util/registry.ts
@@ -8,7 +8,7 @@ import { FileConstructor, objectKindOf } from "./objectKinds.ts"
 // recent node versions (https://nodejs.org/api/esm.html#json-modules).
 
 // For now, we assert this matches the package.json version via a unit test.
-export const arkUtilVersion = "0.43.4"
+export const arkUtilVersion = "0.44.0"
 
 export const initialRegistryContents = {
 	version: arkUtilVersion,


### PR DESCRIPTION
#### Fix JSDoc and go-to definition for unparsed keys

Addresses #1294

```ts
const t = type({
	/** FOO */
	foo: "string",
	/** BAR */
	bar: "number?"
})

const out = t.assert({ foo: "foo" })

// go-to definition will now navigate to the foo prop from the type call
// hovering foo now displays "FOO"
console.log(out.foo)

// go-to definition will now navigate to the bar prop from the type call
// hovering bar now displays "BAR"
// (the ? must be in the value for this to work)
console.log(out.bar)
```