### PR TITLE
include $schema version declaration in json schema exports

### DIFF
--- a/ark/schema/__tests__/jsonSchema.test.ts
+++ b/ark/schema/__tests__/jsonSchema.test.ts
@@ -4,6 +4,7 @@ import { $ark, intrinsic, JsonSchema, rootSchema } from "@ark/schema"
 contextualize(() => {
 	it("base primitives", () => {
 		attest(intrinsic.jsonPrimitive.toJsonSchema()).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			anyOf: [
 				{ type: "number" },
 				{ type: "string" },
@@ -22,6 +23,7 @@ contextualize(() => {
 			maxLength: 2
 		})
 		attest(node.toJsonSchema()).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "string",
 			pattern: ".*",
 			maxLength: 2,
@@ -37,6 +39,7 @@ contextualize(() => {
 			max: 2
 		})
 		attest(node.toJsonSchema()).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "integer",
 			multipleOf: 2,
 			maximum: 2,
@@ -51,6 +54,7 @@ contextualize(() => {
 			max: { rule: 2, exclusive: true }
 		})
 		attest(node.toJsonSchema()).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "number",
 			exclusiveMaximum: 2,
 			exclusiveMinimum: 1
@@ -79,6 +83,7 @@ contextualize(() => {
 			}
 		})
 		attest(node.toJsonSchema()).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "object",
 			properties: {
 				bar: { type: "number" },
@@ -109,6 +114,7 @@ contextualize(() => {
 			}
 		})
 		attest(node.toJsonSchema()).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "object",
 			patternProperties: { ".*": { type: "number" } }
 		})
@@ -123,6 +129,7 @@ contextualize(() => {
 		})
 		const jsonSchema = node.toJsonSchema()
 		attest(jsonSchema).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "array",
 			items: { type: "string" },
 			minItems: 1,
@@ -139,6 +146,7 @@ contextualize(() => {
 		})
 		const jsonSchema = node.toJsonSchema()
 		attest(jsonSchema).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "array",
 			prefixItems: [{ type: "string" }, { type: "number" }],
 			items: false
@@ -155,6 +163,7 @@ contextualize(() => {
 		})
 		const jsonSchema = node.toJsonSchema()
 		attest(jsonSchema).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "array",
 			minItems: 2,
 			prefixItems: [{ type: "string" }, { type: "number" }],
@@ -193,6 +202,7 @@ contextualize(() => {
 		const jsonSchema = node.toJsonSchema()
 
 		attest(jsonSchema).snap({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
 			type: "object",
 			properties: {
 				bar: { type: "number", title: "bar", examples: [1337, 7331] },

--- a/ark/schema/roots/intersection.ts
+++ b/ark/schema/roots/intersection.ts
@@ -313,7 +313,7 @@ export class IntersectionNode extends BaseRoot<Intersection.Declaration> {
 			// cast is required since TS doesn't know children have compatible schema prerequisites
 			(schema, child) =>
 				child.isBasis() ?
-					child.toJsonSchema()
+					child.toJsonSchemaNoVersion()
 				:	child.reduceJsonSchema(schema as never),
 			{}
 		)

--- a/ark/schema/roots/root.ts
+++ b/ark/schema/roots/root.ts
@@ -37,7 +37,7 @@ import {
 	type kindRightOf
 } from "../shared/implement.ts"
 import { intersectNodesRoot, pipeNodesRoot } from "../shared/intersections.ts"
-import type { JsonSchema } from "../shared/jsonSchema.ts"
+import type { FinalJsonSchema, JsonSchema } from "../shared/jsonSchema.ts"
 import { $ark } from "../shared/registry.ts"
 import type { StandardSchemaV1 } from "../shared/standardSchema.ts"
 import { arkKind, hasArkKind } from "../shared/utils.ts"
@@ -119,8 +119,17 @@ export abstract class BaseRoot<
 
 	protected abstract innerToJsonSchema(): JsonSchema
 
-	toJsonSchema(): JsonSchema {
+	toJsonSchemaNoVersion(): JsonSchema {
 		const schema = this.innerToJsonSchema()
+		return Object.assign(schema, this.metaJson)
+	}
+
+	toJsonSchema(): FinalJsonSchema {
+		const schema = {
+			$schema: "https://json-schema.org/draft/2020-12/schema" as const,
+			...this.innerToJsonSchema()
+		}
+
 		return Object.assign(schema, this.metaJson)
 	}
 

--- a/ark/schema/roots/union.ts
+++ b/ark/schema/roots/union.ts
@@ -296,7 +296,7 @@ export class UnionNode extends BaseRoot<Union.Declaration> {
 				// to the canonical JSON Schema representation { type: "boolean" }
 				group.equals($ark.intrinsic.boolean) ?
 					{ type: "boolean" }
-				:	group.toJsonSchema()
+				:	group.toJsonSchemaNoVersion()
 			)
 		}
 	}

--- a/ark/schema/shared/jsonSchema.ts
+++ b/ark/schema/shared/jsonSchema.ts
@@ -12,6 +12,10 @@ import type { ConstraintKind } from "./implement.ts"
 
 export type JsonSchema = JsonSchema.Union | JsonSchema.Branch
 
+export type FinalJsonSchema = {
+	$schema: "https://json-schema.org/draft/2020-12/schema"
+} & JsonSchema
+
 export declare namespace JsonSchema {
 	export type TypeName =
 		| "string"

--- a/ark/schema/structure/sequence.ts
+++ b/ark/schema/structure/sequence.ts
@@ -472,7 +472,7 @@ export class SequenceNode extends BaseConstraint<Sequence.Declaration> {
 
 	reduceJsonSchema(schema: JsonSchema.Array): JsonSchema.Array {
 		if (this.prefix)
-			schema.prefixItems = this.prefix.map(node => node.toJsonSchema())
+			schema.prefixItems = this.prefix.map(node => node.toJsonSchemaNoVersion())
 
 		if (this.optionals) {
 			return JsonSchema.throwUnjsonifiableError(
@@ -481,7 +481,7 @@ export class SequenceNode extends BaseConstraint<Sequence.Declaration> {
 		}
 
 		if (this.variadic) {
-			schema.items = this.variadic?.toJsonSchema()
+			schema.items = this.variadic?.toJsonSchemaNoVersion()
 			// length constraints will be enforced by items: false
 			// for non-variadic arrays
 			if (this.minLength) schema.minItems = this.minLength

--- a/ark/schema/structure/structure.ts
+++ b/ark/schema/structure/structure.ts
@@ -713,15 +713,17 @@ export class StructureNode extends BaseConstraint<Structure.Declaration> {
 					)
 				}
 
-				schema.properties![prop.key] = prop.value.toJsonSchema()
+				schema.properties![prop.key] = prop.value.toJsonSchemaNoVersion()
 			})
 			if (this.requiredKeys.length)
 				schema.required = this.requiredKeys as string[]
 		}
 
 		this.index?.forEach(index => {
-			if (index.signature.equals($ark.intrinsic.string))
-				return (schema.additionalProperties = index.value.toJsonSchema())
+			if (index.signature.equals($ark.intrinsic.string)) {
+				return (schema.additionalProperties =
+					index.value.toJsonSchemaNoVersion())
+			}
 
 			if (!index.signature.extends($ark.intrinsic.string)) {
 				return JsonSchema.throwUnjsonifiableError(
@@ -741,7 +743,7 @@ export class StructureNode extends BaseConstraint<Structure.Declaration> {
 
 				schema.patternProperties ??= {}
 				schema.patternProperties[keyBranch.inner.pattern[0].rule] =
-					index.value.toJsonSchema()
+					index.value.toJsonSchemaNoVersion()
 			})
 		})
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

Hi!

I noticed that the exported JSON Schema object does not include the `$schema` key, which declares the meta schema (and thus declares which version of JSON schema this is intended to be used with)

I used the latest version and hardcoded the string, it might be worth factoring out

In order to only add the $schema key at the top-level, I added a new `.toJsonSchemaNoVersion` method that does what `.toJsonSchema` did before

I wonder if the usages of .toJsonSchema could be replaced with .innerToJsonSchema so we don't have to add a new method?

I also tried putting the version inclusion as an optional argument to .toJsonSchema, but it seems like my typescript powers are not strong enough yet, I get a type error at the Object.assign call when doing

```ts
toJsonSchema<IncludeVersion extends boolean | undefined>(includeVersion?: IncludeVersion): IncludeVersion extends true ? FinalJsonSchema : JsonSchema
```

Thanks a lot for this project, it's really impressive and the DX is _great_ :3
