### PR TITLE
simplify boolean json schema output

### DIFF
--- a/ark/schema/__tests__/jsonSchema.test.ts
+++ b/ark/schema/__tests__/jsonSchema.test.ts
@@ -14,6 +14,12 @@ contextualize(() => {
 		})
 	})
 
+	it("boolean", () => {
+		attest($ark.intrinsic.boolean.toJsonSchema()).snap({
+			type: "boolean"
+		})
+	})
+
 	it("string", () => {
 		const node = rootSchema({
 			domain: "string",

--- a/ark/schema/roots/union.ts
+++ b/ark/schema/roots/union.ts
@@ -290,14 +290,16 @@ export class UnionNode extends BaseRoot<Union.Declaration> {
 	}
 
 	protected innerToJsonSchema(): JsonSchema {
+		// special case to simplify { const: true } | { const: false }
+		// to the canonical JSON Schema representation { type: "boolean" }
+		if (
+			this.branchGroups.length === 1 &&
+			this.branchGroups[0].equals($ark.intrinsic.boolean)
+		)
+			return { type: "boolean" }
+
 		return {
-			anyOf: this.branchGroups.map(group =>
-				// special case to simplify { const: true } | { const: false }
-				// to the canonical JSON Schema representation { type: "boolean" }
-				group.equals($ark.intrinsic.boolean) ?
-					{ type: "boolean" }
-				:	group.toJsonSchema()
-			)
+			anyOf: this.branchGroups.map(group => group.toJsonSchema())
 		}
 	}
 


### PR DESCRIPTION
Slight improvement in json-schema output for boolean types:

Before:

```ts
import {type} from 'arktype'

type('boolean').toJsonSchema() // {anyOf: [{type: 'boolean'}]}
```

After:

```ts
import {type} from 'arktype'

type('boolean').toJsonSchema() // {type: 'boolean'}
```

I just moved the existing special case for booleans a little earlier. There might be a better spot for it though?

* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally
* [x] There are new or updated unit tests validating the change
