### PR TITLE
add docs link for number keywords

### DIFF
--- a/ark/docs/content/docs/primitives/index.mdx
+++ b/ark/docs/content/docs/primitives/index.mdx
@@ -106,7 +106,7 @@ const range = type({
 
 ## number
 
-### keywords
+### keywords [#number-keywords]
 
 The following keywords can be referenced in any definition, e.g.:
 


### PR DESCRIPTION
This link was missing an id so the sidebar didn't link to this section properly.