### PR TITLE
improve .expression for regex constraints

### DIFF
--- a/ark/attest/package.json
+++ b/ark/attest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/attest",
-	"version": "0.45.3",
+	"version": "0.45.4",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/fs/package.json
+++ b/ark/fs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/fs",
-	"version": "0.45.3",
+	"version": "0.45.4",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/schema/package.json
+++ b/ark/schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/schema",
-	"version": "0.45.3",
+	"version": "0.45.4",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/schema/refinements/pattern.ts
+++ b/ark/schema/refinements/pattern.ts
@@ -57,6 +57,7 @@ const implementation: nodeImplementationOf<Pattern.Declaration> =
 				:	{ rule: schema.source }
 			:	schema,
 		obviatesBasisDescription: true,
+		obviatesBasisExpression: true,
 		hasAssociatedError: true,
 		intersectionIsOpen: true,
 		defaults: {

--- a/ark/schema/roots/intersection.ts
+++ b/ark/schema/roots/intersection.ts
@@ -395,7 +395,7 @@ export const Intersection = {
 const writeIntersectionExpression = (node: Intersection.Node) => {
 	let expression =
 		node.structure?.expression ||
-		`${node.basis ? node.basis.nestableExpression + " " : ""}${node.refinements.map(n => n.expression).join(" & ")}` ||
+		`${node.basis && !node.refinements.some(n => n.impl.obviatesBasisExpression) ? node.basis.nestableExpression + " " : ""}${node.refinements.map(n => n.expression).join(" & ")}` ||
 		"unknown"
 	if (expression === "Array == 0") expression = "[]"
 	return expression

--- a/ark/schema/shared/implement.ts
+++ b/ark/schema/shared/implement.ts
@@ -313,6 +313,7 @@ interface CommonNodeImplementationInput<d extends BaseNodeDeclaration> {
 		$: BaseScope
 	) => nodeOfKind<d["reducibleTo"]> | Disjoint | undefined
 	obviatesBasisDescription?: d["kind"] extends RefinementKind ? true : never
+	obviatesBasisExpression?: d["kind"] extends RefinementKind ? true : never
 }
 
 export interface UnknownNodeImplementation

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -1,5 +1,17 @@
 # arktype
 
+## 2.1.14
+
+### improve .expression for regex constraints
+
+```ts
+const t = type(/^a.*z$/)
+
+// old: string /^a.*z$/
+// new: /^a.*z$/
+console.log(t.expression)
+```
+
 ## 2.1.13
 
 ### Add standalone functions for n-ary operators

--- a/ark/type/__tests__/enclosed.test.ts
+++ b/ark/type/__tests__/enclosed.test.ts
@@ -54,7 +54,7 @@ contextualize(() => {
 	it("regex literal", () => {
 		const t = type("/.*/")
 		attest<string>(t.infer)
-		attest(t.expression).snap("string /.*/")
+		attest(t.expression).snap("/.*/")
 	})
 
 	it("invalid regex", () => {

--- a/ark/type/__tests__/pipe.test.ts
+++ b/ark/type/__tests__/pipe.test.ts
@@ -714,10 +714,7 @@ contextualize(() => {
 				c: "a|b"
 			}).export()
 		}).throws(
-			writeIndiscriminableMorphMessage(
-				"string",
-				"(In: string /.*/) => Out<unknown>"
-			)
+			writeIndiscriminableMorphMessage("string", "(In: /.*/) => Out<unknown>")
 		)
 	})
 
@@ -860,7 +857,7 @@ contextualize(() => {
 >`)
 
 		attest(t.expression).snap(
-			"{ l: 1, n: (In: string /^(?:(?!^-0\\.?0*$)(?:-?(?:(?:0|[1-9]\\d*)(?:\\.\\d+)?)|\\.\\d+?))$/) => Out<number> } | { n: (In: string /^(?:(?!^-0\\.?0*$)(?:-?(?:(?:0|[1-9]\\d*)(?:\\.\\d+)?)|\\.\\d+?))$/) => Out<number>, r: 1 }"
+			"{ l: 1, n: (In: /^(?:(?!^-0\\.?0*$)(?:-?(?:(?:0|[1-9]\\d*)(?:\\.\\d+)?)|\\.\\d+?))$/) => Out<number> } | { n: (In: /^(?:(?!^-0\\.?0*$)(?:-?(?:(?:0|[1-9]\\d*)(?:\\.\\d+)?)|\\.\\d+?))$/) => Out<number>, r: 1 }"
 		)
 		attest(t({ l: 1, n: "234" })).snap({ l: 1, n: 234 })
 		attest(t({ r: 1, n: "234" })).snap({ r: 1, n: 234 })

--- a/ark/type/__tests__/realWorld.test.ts
+++ b/ark/type/__tests__/realWorld.test.ts
@@ -1033,7 +1033,7 @@ nospace must be matched by ^\\S*$ (was "One space")`)
 		})
 
 		attest(feedbackSchema.expression).snap(
-			"{ contact: string == 0 | string /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$/ }"
+			"{ contact: string == 0 | /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$/ }"
 		)
 		attest(feedbackSchema.t).type.toString.snap(`{ contact: string }`)
 	})

--- a/ark/type/__tests__/regex.test.ts
+++ b/ark/type/__tests__/regex.test.ts
@@ -87,4 +87,10 @@ contextualize(() => {
 				.type.errors("Property 'matching' does not exist")
 		})
 	})
+
+	it("expression doesn't include string", () => {
+		const t = type(/^a.*z$/)
+
+		attest(t.expression).snap("/^a.*z$/")
+	})
 })

--- a/ark/type/__tests__/type.test.ts
+++ b/ark/type/__tests__/type.test.ts
@@ -249,7 +249,7 @@ contextualize(() => {
 			]
 		})
 		attest(t.expression).snap(
-			"{ [string]: number, a: 1, c: [string <= 4 & >= 1, boolean?, ...number[]], d: [(In: string) => Out<unknown>, number % 2 & < 100 & > 0, ...bigint[], (In: string /^a.*z$/) => Out<string /^[a-z]*$/>[]], b?: 2 }"
+			"{ [string]: number, a: 1, c: [string <= 4 & >= 1, boolean?, ...number[]], d: [(In: string) => Out<unknown>, number % 2 & < 100 & > 0, ...bigint[], (In: /^a.*z$/) => Out</^[a-z]*$/>[]], b?: 2 }"
 		)
 		attest(`${t}`).equals(`Type<${t.expression}>`)
 	})

--- a/ark/type/package.json
+++ b/ark/type/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arktype",
 	"description": "TypeScript's 1:1 validator, optimized from editor to runtime",
-	"version": "2.1.13",
+	"version": "2.1.14",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/ark/util/package.json
+++ b/ark/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/util",
-	"version": "0.45.3",
+	"version": "0.45.4",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/util/registry.ts
+++ b/ark/util/registry.ts
@@ -8,7 +8,7 @@ import { FileConstructor, objectKindOf } from "./objectKinds.ts"
 // recent node versions (https://nodejs.org/api/esm.html#json-modules).
 
 // For now, we assert this matches the package.json version via a unit test.
-export const arkUtilVersion = "0.45.3"
+export const arkUtilVersion = "0.45.4"
 
 export const initialRegistryContents = {
 	version: arkUtilVersion,


### PR DESCRIPTION
### improve .expression for regex constraints

```ts
const t = type(/^a.*z$/)

// old: string /^a.*z$/
// new: /^a.*z$/
console.log(t.expression)
```