### PR TITLE
fix nary type inference for scopes

### DIFF
--- a/ark/attest/__tests__/benchExpectedOutput.ts
+++ b/ark/attest/__tests__/benchExpectedOutput.ts
@@ -30,7 +30,7 @@ type makeComplexType<S extends string> =
 	:	S
 
 bench("bench type", () => ({}) as makeComplexType<"defenestration">).types([
-	176,
+	177,
 	"instantiations"
 ])
 
@@ -45,6 +45,6 @@ bench(
 	fakeCallOptions
 )
 	.mean([2, "ms"])
-	.types([344, "instantiations"])
+	.types([345, "instantiations"])
 
 bench("empty", () => {}).types([0, "instantiations"])

--- a/ark/type/__tests__/match.bench.ts
+++ b/ark/type/__tests__/match.bench.ts
@@ -100,7 +100,7 @@ bench("case(3, invoke)", () => {
 	invokedCases3(31)
 	invokedCases3(32)
 	invokedCases3(33)
-}).types([0, "instantiations"])
+}).types([566, "instantiations"])
 
 const invokedCases10 = match
 	.case("0n", n => `${n}` as const)
@@ -119,10 +119,10 @@ bench("case(10, invoke first)", () => {
 	invokedCases10(0n)
 	invokedCases10(1n)
 	invokedCases10(2n)
-}).types([0, "instantiations"])
+}).types([1201, "instantiations"])
 
 bench("case(10, invoke last)", () => {
 	invokedCases10(7n)
 	invokedCases10(8n)
 	invokedCases10(9n)
-}).types([0, "instantiations"])
+}).types([1201, "instantiations"])

--- a/ark/type/__tests__/nary.test.ts
+++ b/ark/type/__tests__/nary.test.ts
@@ -4,555 +4,10 @@ import { type } from "arktype"
 import type { Out } from "arktype/internal/attributes.ts"
 
 contextualize(() => {
-	describe("union", () => {
-		it("nullary", () => {
-			const T = type.or()
-			attest<never>(T.t)
-
-			attest(T.expression).snap("never")
-			attest(T.$.internal.name).snap("ark")
-		})
-
-		it("unary", () => {
-			const T = type.or("string")
-			attest<string>(T.t)
-			attest(T.expression).snap("string")
-		})
-
-		it("unary with scope", () => {
-			const s = type.scope({
-				a: "1"
-			})
-			const T = s.type.or("a")
-			attest<1>(T.t)
-			attest(T.expression).snap("1")
-		})
-
-		it("binary", () => {
-			const T = type.or("string", "number")
-			attest<string | number>(T.t)
-			attest(T.expression).snap("number | string")
-		})
-
-		it("binary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2"
-			})
-			const T = s.type.or("a", "b")
-			attest<1 | 2>(T.t)
-			attest(T.expression).snap("1 | 2")
-		})
-
-		it("3-ary", () => {
-			const T = type.or("1", "2", "3")
-			attest<1 | 2 | 3>(T.t)
-			attest(T.expression).snap("1 | 2 | 3")
-		})
-
-		it("3-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3"
-			})
-			const T = s.type.or("a", "b", "c")
-			attest<1 | 2 | 3>(T.t)
-			attest(T.expression).snap("1 | 2 | 3")
-		})
-
-		it("4-ary", () => {
-			const T = type.or("1", "2", "3", "4")
-			attest<1 | 2 | 3 | 4>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4")
-		})
-
-		it("4-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4"
-			})
-			const T = s.type.or("a", "b", "c", "d")
-			attest<1 | 2 | 3 | 4>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4")
-		})
-
-		it("5-ary", () => {
-			const T = type.or("1", "2", "3", "4", "5")
-			attest<1 | 2 | 3 | 4 | 5>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5")
-		})
-
-		it("5-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5"
-			})
-			const T = s.type.or("a", "b", "c", "d", "e")
-			attest<1 | 2 | 3 | 4 | 5>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5")
-		})
-
-		it("6-ary", () => {
-			const T = type.or("1", "2", "3", "4", "5", "6")
-			attest<1 | 2 | 3 | 4 | 5 | 6>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6")
-		})
-
-		it("6-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6"
-			})
-			const T = s.type.or("a", "b", "c", "d", "e", "f")
-			attest<1 | 2 | 3 | 4 | 5 | 6>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6")
-		})
-
-		it("7-ary", () => {
-			const T = type.or("1", "2", "3", "4", "5", "6", "7")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7")
-		})
-
-		it("7-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7"
-			})
-			const T = s.type.or("a", "b", "c", "d", "e", "f", "g")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7")
-		})
-
-		it("8-ary", () => {
-			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8")
-		})
-
-		it("8-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8"
-			})
-			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8")
-		})
-
-		it("9-ary", () => {
-			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8", "9")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
-		})
-
-		it("9-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8",
-				i: "9"
-			})
-			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>(T.t)
-			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
-		})
-
-		it("10-ary", () => {
-			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10>(T.t)
-			attest(T.expression).snap("10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
-		})
-
-		it("10-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8",
-				i: "9",
-				j: "10"
-			})
-			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10>(T.t)
-			attest(T.expression).snap("10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
-		})
-
-		it("11-ary", () => {
-			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11>(T.t)
-			attest(T.expression).snap("10 | 11 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
-		})
-
-		it("11-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8",
-				i: "9",
-				j: "10",
-				k: "11"
-			})
-			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11>(T.t)
-			attest(T.expression).snap("10 | 11 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
-		})
-
-		it("12-ary", () => {
-			const T = type.or(
-				"1",
-				"2",
-				"3",
-				"4",
-				"5",
-				"6",
-				"7",
-				"8",
-				"9",
-				"10",
-				"11",
-				"12"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("12-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8",
-				i: "9",
-				j: "10",
-				k: "11",
-				l: "12"
-			})
-			const T = s.type.or(
-				"a",
-				"b",
-				"c",
-				"d",
-				"e",
-				"f",
-				"g",
-				"h",
-				"i",
-				"j",
-				"k",
-				"l"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("13-ary", () => {
-			const T = type.or(
-				"1",
-				"2",
-				"3",
-				"4",
-				"5",
-				"6",
-				"7",
-				"8",
-				"9",
-				"10",
-				"11",
-				"12",
-				"13"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("13-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8",
-				i: "9",
-				j: "10",
-				k: "11",
-				l: "12",
-				m: "13"
-			})
-			const T = s.type.or(
-				"a",
-				"b",
-				"c",
-				"d",
-				"e",
-				"f",
-				"g",
-				"h",
-				"i",
-				"j",
-				"k",
-				"l",
-				"m"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("14-ary", () => {
-			const T = type.or(
-				"1",
-				"2",
-				"3",
-				"4",
-				"5",
-				"6",
-				"7",
-				"8",
-				"9",
-				"10",
-				"11",
-				"12",
-				"13",
-				"14"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 14 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("14-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8",
-				i: "9",
-				j: "10",
-				k: "11",
-				l: "12",
-				m: "13",
-				n: "14"
-			})
-			const T = s.type.or(
-				"a",
-				"b",
-				"c",
-				"d",
-				"e",
-				"f",
-				"g",
-				"h",
-				"i",
-				"j",
-				"k",
-				"l",
-				"m",
-				"n"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 14 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("15-ary", () => {
-			const T = type.or(
-				"1",
-				"2",
-				"3",
-				"4",
-				"5",
-				"6",
-				"7",
-				"8",
-				"9",
-				"10",
-				"11",
-				"12",
-				"13",
-				"14",
-				"15"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15>(
-				T.t
-			)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 14 | 15 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("15-ary with scope", () => {
-			const s = type.scope({
-				a: "1",
-				b: "2",
-				c: "3",
-				d: "4",
-				e: "5",
-				f: "6",
-				g: "7",
-				h: "8",
-				i: "9",
-				j: "10",
-				k: "11",
-				l: "12",
-				m: "13",
-				n: "14",
-				o: "15"
-			})
-			const T = s.type.or(
-				"a",
-				"b",
-				"c",
-				"d",
-				"e",
-				"f",
-				"g",
-				"h",
-				"i",
-				"j",
-				"k",
-				"l",
-				"m",
-				"n",
-				"o"
-			)
-			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15>(
-				T.t
-			)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 14 | 15 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("16-ary", () => {
-			const T = type.or(
-				"1",
-				"2",
-				"3",
-				"4",
-				"5",
-				"6",
-				"7",
-				"8",
-				"9",
-				"10",
-				"11",
-				"12",
-				"13",
-				"14",
-				"15",
-				"16"
-			)
-			attest<
-				1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16
-			>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 14 | 15 | 16 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("n-ary", () => {
-			const T = type.or(
-				"1",
-				"2",
-				"3",
-				"4",
-				"5",
-				"6",
-				"7",
-				"8",
-				"9",
-				"10",
-				"11",
-				"12",
-				"13",
-				"14",
-				"15",
-				"16",
-				"17"
-			)
-
-			attest<
-				| 1
-				| 2
-				| 3
-				| 4
-				| 5
-				| 6
-				| 7
-				| 8
-				| 9
-				| 10
-				| 11
-				| 12
-				| 13
-				| 14
-				| 15
-				| 16
-				| 17
-			>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
-
-		it("n-ary with scope", () => {
-			const s = type.scope({
+	contextualize.each(
+		"union",
+		() => {
+			const $ = type.scope({
 				a: "1",
 				b: "2",
 				c: "3",
@@ -571,427 +26,540 @@ contextualize(() => {
 				p: "16",
 				q: "17"
 			})
-			const T = s.type.or(
-				"a",
-				"b",
-				"c",
-				"d",
-				"e",
-				"f",
-				"g",
-				"h",
-				"i",
-				"j",
-				"k",
-				"l",
-				"m",
-				"n",
-				"o",
-				"p",
-				"q"
-			)
-			attest<
-				| 1
-				| 2
-				| 3
-				| 4
-				| 5
-				| 6
-				| 7
-				| 8
-				| 9
-				| 10
-				| 11
-				| 12
-				| 13
-				| 14
-				| 15
-				| 16
-				| 17
-			>(T.t)
-			attest(T.expression).snap(
-				"10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
-			)
-		})
+			return $
+		},
+		it => {
+			it("nullary", () => {
+				const T = type.or()
+				attest<never>(T.t)
 
-		it("completions", () => {
-			// @ts-expect-error
-			attest(() => type.or("boo", { foo: "big" })).completions({
-				boo: ["boolean"],
-				big: ["bigint"]
+				attest(T.expression).snap("never")
+				attest(T.$.internal.name).snap("ark")
 			})
-		})
 
-		it("spreadable", () => {
-			const types: type[] = []
-
-			const T = type.or(...types)
-
-			attest<unknown>(T.t)
-			attest(T.expression).snap("never")
-		})
-	})
-
-	describe("intersection", () => {
-		it("nullary", () => {
-			const T = type.and()
-			attest<unknown>(T.t)
-			attest(T.expression).snap("unknown")
-			attest(T.$.internal.name).snap("ark")
-		})
-
-		it("unary", () => {
-			const T = type.and("string")
-			attest<string>(T.t)
-			attest(T.expression).snap("string")
-		})
-
-		it("unary with scope", () => {
-			const s = type.scope({
-				a: "string"
+			it("unary", $ => {
+				const T = $.type.or("a")
+				attest<1>(T.t)
+				attest(T.expression).snap("1")
 			})
-			const T = s.type.and("a")
-			attest<string>(T.t)
-			attest(T.expression).snap("string")
-		})
 
-		it("binary", () => {
-			const T = type.and({ a1: "1" }, { a2: "2" })
-			attest<{ a1: 1; a2: 2 }>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2 }")
-		})
-
-		it("binary with scope", () => {
-			const s = type.scope({
-				a: { a1: "1" },
-				b: { a2: "2" }
+			it("binary", $ => {
+				const T = $.type.or("a", "b")
+				attest<1 | 2>(T.t)
+				attest(T.expression).snap("1 | 2")
 			})
-			const T = s.type.and("a", "b")
-			attest<{ a1: 1; a2: 2 }>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2 }")
-		})
 
-		it("3-ary", () => {
-			const T = type.and({ a1: "1" }, { a2: "2" }, { a3: "3" })
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
-		})
-
-		it("3-ary with scope", () => {
-			const s = type.scope({
-				a: { a1: "1" },
-				b: { a2: "2" },
-				c: { a3: "3" }
+			it("3-ary", $ => {
+				const T = $.type.or("a", "b", "c")
+				attest<1 | 2 | 3>(T.t)
+				attest(T.expression).snap("1 | 2 | 3")
 			})
-			const T = s.type.and("a", "b", "c")
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
-		})
 
-		it("4-ary", () => {
-			const T = type.and({ a1: "1" }, { a2: "2" }, { a3: "3" }, { a4: "4" })
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-				a4: 4
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
-		})
-
-		it("4-ary with scope", () => {
-			const s = type.scope({
-				a: { a1: "1" },
-				b: { a2: "2" },
-				c: { a3: "3" },
-				d: { a4: "4" }
+			it("4-ary", $ => {
+				const T = $.type.or("a", "b", "c", "d")
+				attest<1 | 2 | 3 | 4>(T.t)
+				attest(T.expression).snap("1 | 2 | 3 | 4")
 			})
-			const T = s.type.and("a", "b", "c", "d")
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-				a4: 4
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
-		})
 
-		it("5-ary", () => {
-			const T = type.and(
-				{ a1: "1" },
-				{ a2: "2" },
-				{ a3: "3" },
-				{ a4: "4" },
-				{ a5: "5" }
-			)
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-				a4: 4
-				a5: 5
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4, a5: 5 }")
-		})
+			it("5-ary", $ => {
+				const T = $.type.or("a", "b", "c", "d", "e")
+				attest<1 | 2 | 3 | 4 | 5>(T.t)
+				attest(T.expression).snap("1 | 2 | 3 | 4 | 5")
+			})
 
-		it("5-ary with scope", () => {
-			const s = type.scope({
+			it("6-ary", $ => {
+				const T = $.type.or("a", "b", "c", "d", "e", "f")
+				attest<1 | 2 | 3 | 4 | 5 | 6>(T.t)
+				attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6")
+			})
+
+			it("7-ary", $ => {
+				const T = $.type.or("1", "2", "3", "4", "5", "6", "7")
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7>(T.t)
+				attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7")
+			})
+
+			it("8-ary", $ => {
+				const T = $.type.or("a", "b", "c", "d", "e", "f", "g", "h")
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8>(T.t)
+				attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8")
+			})
+
+			it("9-ary", $ => {
+				const T = $.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i")
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>(T.t)
+				attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+			})
+
+			it("10-ary", $ => {
+				const T = $.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10>(T.t)
+				attest(T.expression).snap("10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+			})
+
+			it("11-ary", $ => {
+				const T = $.type.or(
+					"a",
+					"b",
+					"c",
+					"d",
+					"e",
+					"f",
+					"g",
+					"h",
+					"i",
+					"j",
+					"k"
+				)
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11>(T.t)
+				attest(T.expression).snap("10 | 11 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+			})
+
+			it("12-ary", $ => {
+				const T = $.type.or(
+					"a",
+					"b",
+					"c",
+					"d",
+					"e",
+					"f",
+					"g",
+					"h",
+					"i",
+					"j",
+					"k",
+					"l"
+				)
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>(T.t)
+				attest(T.expression).snap(
+					"10 | 11 | 12 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+				)
+			})
+
+			it("13-ary", $ => {
+				const T = $.type.or(
+					"a",
+					"b",
+					"c",
+					"d",
+					"e",
+					"f",
+					"g",
+					"h",
+					"i",
+					"j",
+					"k",
+					"l",
+					"m"
+				)
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13>(T.t)
+				attest(T.expression).snap(
+					"10 | 11 | 12 | 13 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+				)
+			})
+
+			it("14-ary", $ => {
+				const T = $.type.or(
+					"a",
+					"b",
+					"c",
+					"d",
+					"e",
+					"f",
+					"g",
+					"h",
+					"i",
+					"j",
+					"k",
+					"l",
+					"m",
+					"n"
+				)
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14>(T.t)
+				attest(T.expression).snap(
+					"10 | 11 | 12 | 13 | 14 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+				)
+			})
+
+			it("15-ary", $ => {
+				const T = $.type.or(
+					"a",
+					"b",
+					"c",
+					"d",
+					"e",
+					"f",
+					"g",
+					"h",
+					"i",
+					"j",
+					"k",
+					"l",
+					"m",
+					"n",
+					"o"
+				)
+				attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15>(
+					T.t
+				)
+				attest(T.expression).snap(
+					"10 | 11 | 12 | 13 | 14 | 15 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+				)
+			})
+
+			it("16-ary", $ => {
+				const T = $.type.or(
+					"a",
+					"b",
+					"c",
+					"d",
+					"e",
+					"f",
+					"g",
+					"h",
+					"i",
+					"j",
+					"k",
+					"l",
+					"m",
+					"n",
+					"o",
+					"p"
+				)
+				attest<
+					1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16
+				>(T.t)
+				attest(T.expression).snap(
+					"10 | 11 | 12 | 13 | 14 | 15 | 16 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+				)
+			})
+
+			it("n-ary", $ => {
+				const T = $.type.or(
+					"a",
+					"b",
+					"c",
+					"d",
+					"e",
+					"f",
+					"g",
+					"h",
+					"i",
+					"j",
+					"k",
+					"l",
+					"m",
+					"n",
+					"o",
+					"p",
+					"q"
+				)
+
+				attest<
+					| 1
+					| 2
+					| 3
+					| 4
+					| 5
+					| 6
+					| 7
+					| 8
+					| 9
+					| 10
+					| 11
+					| 12
+					| 13
+					| 14
+					| 15
+					| 16
+					| 17
+				>(T.t)
+				attest(T.expression).snap(
+					"10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+				)
+			})
+
+			it("completions", () => {
+				// @ts-expect-error
+				attest(() => type.or("boo", { foo: "big" })).completions({
+					boo: ["boolean"],
+					big: ["bigint"]
+				})
+			})
+
+			it("spreadable", () => {
+				const types: type[] = []
+
+				const T = type.or(...types)
+
+				attest<unknown>(T.t)
+				attest(T.expression).snap("never")
+			})
+		}
+	)
+
+	contextualize.each(
+		"intersection",
+		() => {
+			const $ = type.scope({
 				a: { a1: "1" },
 				b: { a2: "2" },
 				c: { a3: "3" },
 				d: { a4: "4" },
 				e: { a5: "5" }
 			})
-			const T = s.type.and("a", "b", "c", "d", "e")
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-				a4: 4
-				a5: 5
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4, a5: 5 }")
-		})
-
-		// type-perf currently blows up here, investigation:
-		// https://github.com/arktypeio/arktype/issues/1394
-
-		// it("nary", () => {
-		// 	const T = type.and(
-		// 		{ a1: "1" },
-		// 		{ a2: "2" },
-		// 		{ a3: "3" },
-		// 		{ a4: "4" },
-		// 		{ a5: "5" },
-		// 		{ a6: "6" },
-		// 		{ a7: "7" },
-		// 		{ a8: "8" },
-		// 		{ a9: "9" },
-		// 		{ a10: "10" },
-		// 		{ a11: "11" },
-		// 		{ a12: "12" },
-		// 		{ a13: "13" },
-		// 		{ a14: "14" },
-		// 		{ a15: "15" },
-		// 		{ a16: "16" },
-		// 		{ a17: "17" }
-		// 	)
-
-		// attest<{
-		// 	a1: 1
-		// 	a10: 10
-		// 	a11: 11
-		// 	a12: 12
-		// 	a13: 13
-		// 	a14: 14
-		// 	a15: 15
-		// 	a16: 16
-		// 	a17: 17
-		// 	a2: 2
-		// 	a3: 3
-		// 	a4: 4
-		// 	a5: 5
-		// 	a6: 6
-		// 	a7: 7
-		// 	a8: 8
-		// 	a9: 9
-		// }>(T.t)
-		// 	attest(T.expression).snap(
-		// 		"{ a1: 1, a10: 10, a11: 11, a12: 12, a13: 13, a14: 14, a15: 15, a16: 16, a17: 17, a2: 2, a3: 3, a4: 4, a5: 5, a6: 6, a7: 7, a8: 8, a9: 9 }"
-		// 	)
-		// })
-
-		it("completions", () => {
-			// @ts-expect-error
-			attest(() => type.and("boo", { foo: "big" })).completions({
-				boo: ["boolean"],
-				big: ["bigint"]
+			return $
+		},
+		it => {
+			it("nullary", () => {
+				const T = type.and()
+				attest<unknown>(T.t)
+				attest(T.expression).snap("unknown")
+				attest(T.$.internal.name).snap("ark")
 			})
-		})
 
-		it("spreadable", () => {
-			const types: type[] = []
-
-			const T = type.and(...types)
-
-			attest<unknown>(T.t)
-			attest(T.expression).snap("unknown")
-		})
-	})
-
-	describe("merge", () => {
-		it("nullary", () => {
-			const T = type.merge()
-			attest<object>(T.t)
-			attest(T.expression).snap("object")
-			attest(T.$.internal.name).snap("ark")
-		})
-
-		it("unary", () => {
-			const T = type.merge({ a: "string" })
-			attest<{ a: string }>(T.t)
-			attest(T.expression).snap("{ a: string }")
-		})
-
-		it("binary", () => {
-			const T = type.merge({ a1: "1" }, { a2: "2" })
-			attest<{ a1: 1; a2: 2 }>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2 }")
-		})
-
-		it("binary with scope", () => {
-			const s = type.scope({
-				a: { a1: "1" },
-				b: { a2: "2" }
+			it("unary", $ => {
+				const T = $.type.and("a")
+				attest<{ a1: 1 }>(T.t)
+				attest(T.expression).snap("{ a1: 1 }")
 			})
-			const T = s.type.merge("a", "b")
-			attest<{ a1: 1; a2: 2 }>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2 }")
-		})
 
-		it("3-ary", () => {
-			const T = type.merge({ a1: "1" }, { a2: "2" }, { a3: "3" })
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
-		})
-
-		it("3-ary with scope", () => {
-			const s = type.scope({
-				a: { a1: "1" },
-				b: { a2: "2" },
-				c: { a3: "3" }
+			it("binary", $ => {
+				const T = $.type.and("a", "b")
+				attest<{ a1: 1; a2: 2 }>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2 }")
 			})
-			const T = s.type.merge("a", "b", "c")
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
-		})
 
-		it("4-ary", () => {
-			const T = type.merge({ a1: "1" }, { a2: "2" }, { a3: "3" }, { a4: "4" })
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-				a4: 4
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
-		})
+			it("3-ary", $ => {
+				const T = $.type.and("a", "b", "c")
+				attest<{
+					a1: 1
+					a2: 2
+					a3: 3
+				}>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
+			})
 
-		it("4-ary with scope", () => {
-			const s = type.scope({
+			it("4-ary", $ => {
+				const T = $.type.and("a", "b", "c", "d")
+				attest<{
+					a1: 1
+					a2: 2
+					a3: 3
+					a4: 4
+				}>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
+			})
+
+			it("5-ary", $ => {
+				const T = $.type.and("a", "b", "c", "d", "e")
+				attest<{
+					a1: 1
+					a2: 2
+					a3: 3
+					a4: 4
+					a5: 5
+				}>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4, a5: 5 }")
+			})
+
+			// type-perf currently blows up here, investigation:
+			// https://github.com/arktypeio/arktype/issues/1394
+
+			// it("nary", () => {
+			// 	const T = type.and(
+			// 		{ a1: "1" },
+			// 		{ a2: "2" },
+			// 		{ a3: "3" },
+			// 		{ a4: "4" },
+			// 		{ a5: "5" },
+			// 		{ a6: "6" },
+			// 		{ a7: "7" },
+			// 		{ a8: "8" },
+			// 		{ a9: "9" },
+			// 		{ a10: "10" },
+			// 		{ a11: "11" },
+			// 		{ a12: "12" },
+			// 		{ a13: "13" },
+			// 		{ a14: "14" },
+			// 		{ a15: "15" },
+			// 		{ a16: "16" },
+			// 		{ a17: "17" }
+			// 	)
+
+			// attest<{
+			// 	a1: 1
+			// 	a10: 10
+			// 	a11: 11
+			// 	a12: 12
+			// 	a13: 13
+			// 	a14: 14
+			// 	a15: 15
+			// 	a16: 16
+			// 	a17: 17
+			// 	a2: 2
+			// 	a3: 3
+			// 	a4: 4
+			// 	a5: 5
+			// 	a6: 6
+			// 	a7: 7
+			// 	a8: 8
+			// 	a9: 9
+			// }>(T.t)
+			// 	attest(T.expression).snap(
+			// 		"{ a1: 1, a10: 10, a11: 11, a12: 12, a13: 13, a14: 14, a15: 15, a16: 16, a17: 17, a2: 2, a3: 3, a4: 4, a5: 5, a6: 6, a7: 7, a8: 8, a9: 9 }"
+			// 	)
+			// })
+
+			it("completions", () => {
+				// @ts-expect-error
+				attest(() => type.and("boo", { foo: "big" })).completions({
+					boo: ["boolean"],
+					big: ["bigint"]
+				})
+			})
+
+			it("spreadable", () => {
+				const types: type[] = []
+
+				const T = type.and(...types)
+
+				attest<unknown>(T.t)
+				attest(T.expression).snap("unknown")
+			})
+		}
+	)
+
+	contextualize.each(
+		"merge",
+		() => {
+			const $ = type.scope({
 				a: { a1: "1" },
 				b: { a2: "2" },
 				c: { a3: "3" },
-				d: { a4: "4" }
+				d: { a4: "4" },
+				e: { a5: "5" }
 			})
-			const T = s.type.merge("a", "b", "c", "d")
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-				a4: 4
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
-		})
-
-		it("5-ary", () => {
-			const T = type.merge(
-				{ a1: "1" },
-				{ a2: "2" },
-				{ a3: "3" },
-				{ a4: "4" },
-				{ a5: "5" }
-			)
-
-			attest<{
-				a1: 1
-				a2: 2
-				a3: 3
-				a4: 4
-				a5: 5
-			}>(T.t)
-			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4, a5: 5 }")
-		})
-
-		// type-perf currently blows up here, investigation:
-		// https://github.com/arktypeio/arktype/issues/1394
-
-		// it("nary", () => {
-		// 	const T = type.merge(
-		// 		{ a1: "1" },
-		// 		{ a2: "2" },
-		// 		{ a3: "3" },
-		// 		{ a4: "4" },
-		// 		{ a5: "5" },
-		// 		{ a6: "6" },
-		// 		{ a7: "7" },
-		// 		{ a8: "8" },
-		// 		{ a9: "9" },
-		// 		{ a10: "10" },
-		// 		{ a11: "11" },
-		// 		{ a12: "12" },
-		// 		{ a13: "13" },
-		// 		{ a14: "14" },
-		// 		{ a15: "15" },
-		// 		{ a16: "16" },
-		// 		{ a17: "17" }
-		// 	)
-
-		// 	attest<{
-		// 		a1: 1
-		// 		a2: 2
-		// 		a3: 3
-		// 		a4: 4
-		// 		a5: 5
-		// 		a6: 6
-		// 		a7: 7
-		// 		a8: 8
-		// 		a9: 9
-		// 		a10: 10
-		// 		a11: 11
-		// 		a12: 12
-		// 		a13: 13
-		// 		a14: 14
-		// 		a15: 15
-		// 		a16: 16
-		// 		a17: 17
-		// 	}>(T.t)
-		// 	attest(T.expression).snap()
-		// })
-
-		it("completions", () => {
-			// @ts-expect-error
-			attest(() => type.merge({ boo: "boo" }, { foo: "big" })).completions({
-				big: ["bigint"],
-				boo: ["boolean"]
+			return $
+		},
+		it => {
+			it("nullary", () => {
+				const T = type.merge()
+				attest<object>(T.t)
+				attest(T.expression).snap("object")
+				attest(T.$.internal.name).snap("ark")
 			})
-		})
 
-		it("spreadable", () => {
-			const types: type<object>[] = []
+			it("unary", $ => {
+				const T = $.type.merge("a")
+				attest<{ a1: 1 }>(T.t)
+				attest(T.expression).snap("{ a1: 1 }")
+			})
 
-			const T = type.merge(...types)
+			it("binary", $ => {
+				const T = $.type.merge("a", "b")
+				attest<{ a1: 1; a2: 2 }>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2 }")
+			})
 
-			attest<{}>(T.t)
-			attest(T.expression).snap("object")
-		})
-	})
+			it("3-ary", $ => {
+				const T = $.type.merge("a", "b", "c")
+				attest<{
+					a1: 1
+					a2: 2
+					a3: 3
+				}>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
+			})
+
+			it("4-ary", $ => {
+				const T = $.type.merge("a", "b", "c", "d")
+				attest<{
+					a1: 1
+					a2: 2
+					a3: 3
+					a4: 4
+				}>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
+			})
+
+			it("5-ary", $ => {
+				const T = $.type.merge("a", "b", "c", "d", "e")
+
+				attest<{
+					a1: 1
+					a2: 2
+					a3: 3
+					a4: 4
+					a5: 5
+				}>(T.t)
+				attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4, a5: 5 }")
+			})
+
+			// type-perf currently blows up here, investigation:
+			// https://github.com/arktypeio/arktype/issues/1394
+
+			// it("nary", () => {
+			// 	const T = type.merge(
+			// 		{ a1: "1" },
+			// 		{ a2: "2" },
+			// 		{ a3: "3" },
+			// 		{ a4: "4" },
+			// 		{ a5: "5" },
+			// 		{ a6: "6" },
+			// 		{ a7: "7" },
+			// 		{ a8: "8" },
+			// 		{ a9: "9" },
+			// 		{ a10: "10" },
+			// 		{ a11: "11" },
+			// 		{ a12: "12" },
+			// 		{ a13: "13" },
+			// 		{ a14: "14" },
+			// 		{ a15: "15" },
+			// 		{ a16: "16" },
+			// 		{ a17: "17" }
+			// 	)
+
+			// 	attest<{
+			// 		a1: 1
+			// 		a2: 2
+			// 		a3: 3
+			// 		a4: 4
+			// 		a5: 5
+			// 		a6: 6
+			// 		a7: 7
+			// 		a8: 8
+			// 		a9: 9
+			// 		a10: 10
+			// 		a11: 11
+			// 		a12: 12
+			// 		a13: 13
+			// 		a14: 14
+			// 		a15: 15
+			// 		a16: 16
+			// 		a17: 17
+			// 	}>(T.t)
+			// 	attest(T.expression).snap()
+			// })
+
+			it("completions", () => {
+				// @ts-expect-error
+				attest(() => type.merge({ boo: "boo" }, { foo: "big" })).completions({
+					big: ["bigint"],
+					boo: ["boolean"]
+				})
+			})
+
+			it("spreadable", () => {
+				const types: type<object>[] = []
+
+				const T = type.merge(...types)
+
+				attest<{}>(T.t)
+				attest(T.expression).snap("object")
+			})
+		}
+	)
 
 	describe("pipe", () => {
 		it("nullary", () => {

--- a/ark/type/__tests__/nary.test.ts
+++ b/ark/type/__tests__/nary.test.ts
@@ -19,13 +19,494 @@ contextualize(() => {
 			attest(T.expression).snap("string")
 		})
 
+		it("unary with scope", () => {
+			const s = type.scope({
+				a: "1"
+			})
+			const T = s.type.or("a")
+			attest<1>(T.t)
+			attest(T.expression).snap("1")
+		})
+
 		it("binary", () => {
 			const T = type.or("string", "number")
 			attest<string | number>(T.t)
 			attest(T.expression).snap("number | string")
 		})
 
-		it("nary", () => {
+		it("binary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2"
+			})
+			const T = s.type.or("a", "b")
+			attest<1 | 2>(T.t)
+			attest(T.expression).snap("1 | 2")
+		})
+
+		it("3-ary", () => {
+			const T = type.or("1", "2", "3")
+			attest<1 | 2 | 3>(T.t)
+			attest(T.expression).snap("1 | 2 | 3")
+		})
+
+		it("3-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3"
+			})
+			const T = s.type.or("a", "b", "c")
+			attest<1 | 2 | 3>(T.t)
+			attest(T.expression).snap("1 | 2 | 3")
+		})
+
+		it("4-ary", () => {
+			const T = type.or("1", "2", "3", "4")
+			attest<1 | 2 | 3 | 4>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4")
+		})
+
+		it("4-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4"
+			})
+			const T = s.type.or("a", "b", "c", "d")
+			attest<1 | 2 | 3 | 4>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4")
+		})
+
+		it("5-ary", () => {
+			const T = type.or("1", "2", "3", "4", "5")
+			attest<1 | 2 | 3 | 4 | 5>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5")
+		})
+
+		it("5-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5"
+			})
+			const T = s.type.or("a", "b", "c", "d", "e")
+			attest<1 | 2 | 3 | 4 | 5>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5")
+		})
+
+		it("6-ary", () => {
+			const T = type.or("1", "2", "3", "4", "5", "6")
+			attest<1 | 2 | 3 | 4 | 5 | 6>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6")
+		})
+
+		it("6-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6"
+			})
+			const T = s.type.or("a", "b", "c", "d", "e", "f")
+			attest<1 | 2 | 3 | 4 | 5 | 6>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6")
+		})
+
+		it("7-ary", () => {
+			const T = type.or("1", "2", "3", "4", "5", "6", "7")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7")
+		})
+
+		it("7-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7"
+			})
+			const T = s.type.or("a", "b", "c", "d", "e", "f", "g")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7")
+		})
+
+		it("8-ary", () => {
+			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8")
+		})
+
+		it("8-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8"
+			})
+			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8")
+		})
+
+		it("9-ary", () => {
+			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8", "9")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+		})
+
+		it("9-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9"
+			})
+			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>(T.t)
+			attest(T.expression).snap("1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+		})
+
+		it("10-ary", () => {
+			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10>(T.t)
+			attest(T.expression).snap("10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+		})
+
+		it("10-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9",
+				j: "10"
+			})
+			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10>(T.t)
+			attest(T.expression).snap("10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+		})
+
+		it("11-ary", () => {
+			const T = type.or("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11>(T.t)
+			attest(T.expression).snap("10 | 11 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+		})
+
+		it("11-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9",
+				j: "10",
+				k: "11"
+			})
+			const T = s.type.or("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11>(T.t)
+			attest(T.expression).snap("10 | 11 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9")
+		})
+
+		it("12-ary", () => {
+			const T = type.or(
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"6",
+				"7",
+				"8",
+				"9",
+				"10",
+				"11",
+				"12"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("12-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9",
+				j: "10",
+				k: "11",
+				l: "12"
+			})
+			const T = s.type.or(
+				"a",
+				"b",
+				"c",
+				"d",
+				"e",
+				"f",
+				"g",
+				"h",
+				"i",
+				"j",
+				"k",
+				"l"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("13-ary", () => {
+			const T = type.or(
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"6",
+				"7",
+				"8",
+				"9",
+				"10",
+				"11",
+				"12",
+				"13"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("13-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9",
+				j: "10",
+				k: "11",
+				l: "12",
+				m: "13"
+			})
+			const T = s.type.or(
+				"a",
+				"b",
+				"c",
+				"d",
+				"e",
+				"f",
+				"g",
+				"h",
+				"i",
+				"j",
+				"k",
+				"l",
+				"m"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("14-ary", () => {
+			const T = type.or(
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"6",
+				"7",
+				"8",
+				"9",
+				"10",
+				"11",
+				"12",
+				"13",
+				"14"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 14 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("14-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9",
+				j: "10",
+				k: "11",
+				l: "12",
+				m: "13",
+				n: "14"
+			})
+			const T = s.type.or(
+				"a",
+				"b",
+				"c",
+				"d",
+				"e",
+				"f",
+				"g",
+				"h",
+				"i",
+				"j",
+				"k",
+				"l",
+				"m",
+				"n"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 14 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("15-ary", () => {
+			const T = type.or(
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"6",
+				"7",
+				"8",
+				"9",
+				"10",
+				"11",
+				"12",
+				"13",
+				"14",
+				"15"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15>(
+				T.t
+			)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 14 | 15 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("15-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9",
+				j: "10",
+				k: "11",
+				l: "12",
+				m: "13",
+				n: "14",
+				o: "15"
+			})
+			const T = s.type.or(
+				"a",
+				"b",
+				"c",
+				"d",
+				"e",
+				"f",
+				"g",
+				"h",
+				"i",
+				"j",
+				"k",
+				"l",
+				"m",
+				"n",
+				"o"
+			)
+			attest<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15>(
+				T.t
+			)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 14 | 15 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("16-ary", () => {
+			const T = type.or(
+				"1",
+				"2",
+				"3",
+				"4",
+				"5",
+				"6",
+				"7",
+				"8",
+				"9",
+				"10",
+				"11",
+				"12",
+				"13",
+				"14",
+				"15",
+				"16"
+			)
+			attest<
+				1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16
+			>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 14 | 15 | 16 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("n-ary", () => {
 			const T = type.or(
 				"1",
 				"2",
@@ -46,6 +527,69 @@ contextualize(() => {
 				"17"
 			)
 
+			attest<
+				| 1
+				| 2
+				| 3
+				| 4
+				| 5
+				| 6
+				| 7
+				| 8
+				| 9
+				| 10
+				| 11
+				| 12
+				| 13
+				| 14
+				| 15
+				| 16
+				| 17
+			>(T.t)
+			attest(T.expression).snap(
+				"10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9"
+			)
+		})
+
+		it("n-ary with scope", () => {
+			const s = type.scope({
+				a: "1",
+				b: "2",
+				c: "3",
+				d: "4",
+				e: "5",
+				f: "6",
+				g: "7",
+				h: "8",
+				i: "9",
+				j: "10",
+				k: "11",
+				l: "12",
+				m: "13",
+				n: "14",
+				o: "15",
+				p: "16",
+				q: "17"
+			})
+			const T = s.type.or(
+				"a",
+				"b",
+				"c",
+				"d",
+				"e",
+				"f",
+				"g",
+				"h",
+				"i",
+				"j",
+				"k",
+				"l",
+				"m",
+				"n",
+				"o",
+				"p",
+				"q"
+			)
 			attest<
 				| 1
 				| 2
@@ -102,10 +646,82 @@ contextualize(() => {
 			attest(T.expression).snap("string")
 		})
 
+		it("unary with scope", () => {
+			const s = type.scope({
+				a: "string"
+			})
+			const T = s.type.and("a")
+			attest<string>(T.t)
+			attest(T.expression).snap("string")
+		})
+
 		it("binary", () => {
-			const T = type.and({ a: "string" }, { b: "number" })
-			attest<{ a: string; b: number }>(T.t)
-			attest(T.expression).snap("{ a: string, b: number }")
+			const T = type.and({ a1: "1" }, { a2: "2" })
+			attest<{ a1: 1; a2: 2 }>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2 }")
+		})
+
+		it("binary with scope", () => {
+			const s = type.scope({
+				a: { a1: "1" },
+				b: { a2: "2" }
+			})
+			const T = s.type.and("a", "b")
+			attest<{ a1: 1; a2: 2 }>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2 }")
+		})
+
+		it("3-ary", () => {
+			const T = type.and({ a1: "1" }, { a2: "2" }, { a3: "3" })
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
+		})
+
+		it("3-ary with scope", () => {
+			const s = type.scope({
+				a: { a1: "1" },
+				b: { a2: "2" },
+				c: { a3: "3" }
+			})
+			const T = s.type.and("a", "b", "c")
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
+		})
+
+		it("4-ary", () => {
+			const T = type.and({ a1: "1" }, { a2: "2" }, { a3: "3" }, { a4: "4" })
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+				a4: 4
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
+		})
+
+		it("4-ary with scope", () => {
+			const s = type.scope({
+				a: { a1: "1" },
+				b: { a2: "2" },
+				c: { a3: "3" },
+				d: { a4: "4" }
+			})
+			const T = s.type.and("a", "b", "c", "d")
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+				a4: 4
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
 		})
 
 		it("5-ary", () => {
@@ -116,7 +732,25 @@ contextualize(() => {
 				{ a4: "4" },
 				{ a5: "5" }
 			)
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+				a4: 4
+				a5: 5
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4, a5: 5 }")
+		})
 
+		it("5-ary with scope", () => {
+			const s = type.scope({
+				a: { a1: "1" },
+				b: { a2: "2" },
+				c: { a3: "3" },
+				d: { a4: "4" },
+				e: { a5: "5" }
+			})
+			const T = s.type.and("a", "b", "c", "d", "e")
 			attest<{
 				a1: 1
 				a2: 2
@@ -208,9 +842,72 @@ contextualize(() => {
 		})
 
 		it("binary", () => {
-			const T = type.merge({ a: "string" }, { b: "number" })
-			attest<{ a: string; b: number }>(T.t)
-			attest(T.expression).snap("{ a: string, b: number }")
+			const T = type.merge({ a1: "1" }, { a2: "2" })
+			attest<{ a1: 1; a2: 2 }>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2 }")
+		})
+
+		it("binary with scope", () => {
+			const s = type.scope({
+				a: { a1: "1" },
+				b: { a2: "2" }
+			})
+			const T = s.type.merge("a", "b")
+			attest<{ a1: 1; a2: 2 }>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2 }")
+		})
+
+		it("3-ary", () => {
+			const T = type.merge({ a1: "1" }, { a2: "2" }, { a3: "3" })
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
+		})
+
+		it("3-ary with scope", () => {
+			const s = type.scope({
+				a: { a1: "1" },
+				b: { a2: "2" },
+				c: { a3: "3" }
+			})
+			const T = s.type.merge("a", "b", "c")
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3 }")
+		})
+
+		it("4-ary", () => {
+			const T = type.merge({ a1: "1" }, { a2: "2" }, { a3: "3" }, { a4: "4" })
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+				a4: 4
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
+		})
+
+		it("4-ary with scope", () => {
+			const s = type.scope({
+				a: { a1: "1" },
+				b: { a2: "2" },
+				c: { a3: "3" },
+				d: { a4: "4" }
+			})
+			const T = s.type.merge("a", "b", "c", "d")
+			attest<{
+				a1: 1
+				a2: 2
+				a3: 3
+				a4: 4
+			}>(T.t)
+			attest(T.expression).snap("{ a1: 1, a2: 2, a3: 3, a4: 4 }")
 		})
 
 		it("5-ary", () => {
@@ -322,6 +1019,237 @@ contextualize(() => {
 			})
 			attest<(In: string) => Out<string>>(T.t)
 			attest(T.expression).snap("(In: string) => Out<unknown>")
+		})
+
+		it("3-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const
+			)
+			attest<"abc">(T.infer)
+			attest(T("a")).equals("abc")
+		})
+
+		it("4-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const
+			)
+			attest<"abcd">(T.infer)
+			attest(T("a")).equals("abcd")
+		})
+
+		it("5-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const
+			)
+			attest<"abcde">(T.infer)
+			attest(T("a")).equals("abcde")
+		})
+
+		it("6-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const
+			)
+			attest<"abcdef">(T.infer)
+			attest(T("a")).equals("abcdef")
+		})
+
+		it("7-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const
+			)
+			attest<"abcdefg">(T.infer)
+			attest(T("a")).equals("abcdefg")
+		})
+
+		it("8-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const
+			)
+			attest<"abcdefgh">(T.infer)
+			attest(T("a")).equals("abcdefgh")
+		})
+
+		it("9-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const
+			)
+			attest<"abcdefghi">(T.infer)
+			attest(T("a")).equals("abcdefghi")
+		})
+
+		it("10-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const,
+				s => `${s}j` as const
+			)
+			attest<"abcdefghij">(T.infer)
+			attest(T("a")).equals("abcdefghij")
+		})
+
+		it("11-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const,
+				s => `${s}j` as const,
+				s => `${s}k` as const
+			)
+			attest<"abcdefghijk">(T.infer)
+			attest(T("a")).equals("abcdefghijk")
+		})
+
+		it("12-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const,
+				s => `${s}j` as const,
+				s => `${s}k` as const,
+				s => `${s}l` as const
+			)
+			attest<"abcdefghijkl">(T.infer)
+			attest(T("a")).equals("abcdefghijkl")
+		})
+
+		it("13-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const,
+				s => `${s}j` as const,
+				s => `${s}k` as const,
+				s => `${s}l` as const,
+				s => `${s}m` as const
+			)
+			attest<"abcdefghijklm">(T.infer)
+			attest(T("a")).equals("abcdefghijklm")
+		})
+
+		it("14-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const,
+				s => `${s}j` as const,
+				s => `${s}k` as const,
+				s => `${s}l` as const,
+				s => `${s}m` as const,
+				s => `${s}n` as const
+			)
+			attest<"abcdefghijklmn">(T.infer)
+			attest(T("a")).equals("abcdefghijklmn")
+		})
+
+		it("15-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const,
+				s => `${s}j` as const,
+				s => `${s}k` as const,
+				s => `${s}l` as const,
+				s => `${s}m` as const,
+				s => `${s}n` as const,
+				s => `${s}o` as const
+			)
+			attest<"abcdefghijklmno">(T.infer)
+			attest(T("a")).equals("abcdefghijklmno")
+		})
+
+		it("16-ary", () => {
+			const T = type.pipe(
+				type.unit("a"),
+				s => `${s}b` as const,
+				s => `${s}c` as const,
+				s => `${s}d` as const,
+				s => `${s}e` as const,
+				s => `${s}f` as const,
+				s => `${s}g` as const,
+				s => `${s}h` as const,
+				s => `${s}i` as const,
+				s => `${s}j` as const,
+				s => `${s}k` as const,
+				s => `${s}l` as const,
+				s => `${s}m` as const,
+				s => `${s}n` as const,
+				s => `${s}o` as const,
+				s => `${s}p` as const
+			)
+			attest<"abcdefghijklmnop">(T.infer)
+			attest(T("a")).equals("abcdefghijklmnop")
 		})
 
 		it("nary", () => {

--- a/ark/type/__tests__/operator.bench.ts
+++ b/ark/type/__tests__/operator.bench.ts
@@ -129,7 +129,7 @@ bench("morph-chain-all", () => {
 		s => `${s}r` as const
 	)
 	return out
-}).types([0, "instantiations"])
+}).types([7903, "instantiations"])
 
 bench("to-string", () => type("string.numeric.parse |> number.integer")).types([
 	2340,

--- a/ark/type/nary.ts
+++ b/ark/type/nary.ts
@@ -16,10 +16,10 @@ import type { Type } from "./type.ts"
 
 export type NaryUnionParser<$> = {
 	(): Type<never, $>
-	<const a, r = Type<type.infer<a>, $>>(
+	<const a, r = Type<type.infer<a, $>, $>>(
 		a: type.validate<a, $>
 	): r extends infer _ ? _ : never
-	<const a, const b, r = Type<type.infer<a> | type.infer<b>, $>>(
+	<const a, const b, r = Type<type.infer<a, $> | type.infer<b, $>, $>>(
 		a: type.validate<a, $>,
 		b: type.validate<b, $>
 	): r extends infer _ ? _ : never
@@ -27,7 +27,7 @@ export type NaryUnionParser<$> = {
 		const a,
 		const b,
 		const c,
-		r = Type<type.infer<a> | type.infer<b> | type.infer<c>, $>
+		r = Type<type.infer<a, $> | type.infer<b, $> | type.infer<c, $>, $>
 	>(
 		a: type.validate<a, $>,
 		b: type.validate<b, $>,
@@ -38,7 +38,10 @@ export type NaryUnionParser<$> = {
 		const b,
 		const c,
 		const d,
-		r = Type<type.infer<a> | type.infer<b> | type.infer<c> | type.infer<d>, $>
+		r = Type<
+			type.infer<a, $> | type.infer<b, $> | type.infer<c, $> | type.infer<d, $>,
+			$
+		>
 	>(
 		a: type.validate<a, $>,
 		b: type.validate<b, $>,
@@ -52,11 +55,11 @@ export type NaryUnionParser<$> = {
 		const d,
 		const e,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>,
 			$
 		>
 	>(
@@ -74,12 +77,12 @@ export type NaryUnionParser<$> = {
 		const e,
 		const f,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>,
 			$
 		>
 	>(
@@ -99,13 +102,13 @@ export type NaryUnionParser<$> = {
 		const f,
 		const g,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>,
 			$
 		>
 	>(
@@ -127,14 +130,14 @@ export type NaryUnionParser<$> = {
 		const g,
 		const h,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>,
 			$
 		>
 	>(
@@ -158,15 +161,15 @@ export type NaryUnionParser<$> = {
 		const h,
 		const i,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>,
 			$
 		>
 	>(
@@ -192,17 +195,16 @@ export type NaryUnionParser<$> = {
 		const i,
 		const j,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>,
-			$
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
 		>
 	>(
 		a: type.validate<a, $>,
@@ -229,18 +231,17 @@ export type NaryUnionParser<$> = {
 		const j,
 		const k,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>
-			| type.infer<k>,
-			$
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
+			| type.infer<k, $>
 		>
 	>(
 		a: type.validate<a, $>,
@@ -269,18 +270,18 @@ export type NaryUnionParser<$> = {
 		const k,
 		const l,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>
-			| type.infer<k>
-			| type.infer<l>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
+			| type.infer<k, $>
+			| type.infer<l, $>,
 			$
 		>
 	>(
@@ -312,19 +313,19 @@ export type NaryUnionParser<$> = {
 		const l,
 		const m,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>
-			| type.infer<k>
-			| type.infer<l>
-			| type.infer<m>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
+			| type.infer<k, $>
+			| type.infer<l, $>
+			| type.infer<m, $>,
 			$
 		>
 	>(
@@ -358,20 +359,20 @@ export type NaryUnionParser<$> = {
 		const m,
 		const n,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>
-			| type.infer<k>
-			| type.infer<l>
-			| type.infer<m>
-			| type.infer<n>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
+			| type.infer<k, $>
+			| type.infer<l, $>
+			| type.infer<m, $>
+			| type.infer<n, $>,
 			$
 		>
 	>(
@@ -407,21 +408,21 @@ export type NaryUnionParser<$> = {
 		const n,
 		const o,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>
-			| type.infer<k>
-			| type.infer<l>
-			| type.infer<m>
-			| type.infer<n>
-			| type.infer<o>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
+			| type.infer<k, $>
+			| type.infer<l, $>
+			| type.infer<m, $>
+			| type.infer<n, $>
+			| type.infer<o, $>,
 			$
 		>
 	>(
@@ -459,22 +460,22 @@ export type NaryUnionParser<$> = {
 		const o,
 		const p,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>
-			| type.infer<k>
-			| type.infer<l>
-			| type.infer<m>
-			| type.infer<n>
-			| type.infer<o>
-			| type.infer<p>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
+			| type.infer<k, $>
+			| type.infer<l, $>
+			| type.infer<m, $>
+			| type.infer<n, $>
+			| type.infer<o, $>
+			| type.infer<p, $>,
 			$
 		>
 	>(
@@ -514,23 +515,23 @@ export type NaryUnionParser<$> = {
 		const p,
 		const q,
 		r = Type<
-			| type.infer<a>
-			| type.infer<b>
-			| type.infer<c>
-			| type.infer<d>
-			| type.infer<e>
-			| type.infer<f>
-			| type.infer<g>
-			| type.infer<h>
-			| type.infer<i>
-			| type.infer<j>
-			| type.infer<k>
-			| type.infer<l>
-			| type.infer<m>
-			| type.infer<n>
-			| type.infer<o>
-			| type.infer<p>
-			| type.infer<q>,
+			| type.infer<a, $>
+			| type.infer<b, $>
+			| type.infer<c, $>
+			| type.infer<d, $>
+			| type.infer<e, $>
+			| type.infer<f, $>
+			| type.infer<g, $>
+			| type.infer<h, $>
+			| type.infer<i, $>
+			| type.infer<j, $>
+			| type.infer<k, $>
+			| type.infer<l, $>
+			| type.infer<m, $>
+			| type.infer<n, $>
+			| type.infer<o, $>
+			| type.infer<p, $>
+			| type.infer<q, $>,
 			$
 		>
 	>(
@@ -562,13 +563,13 @@ export type NaryUnionParser<$> = {
 
 export type NaryIntersectionParser<$> = {
 	(): Type<unknown, $>
-	<const a, r = Type<type.infer<a>, $>>(
+	<const a, r = Type<type.infer<a, $>, $>>(
 		a: type.validate<a, $>
 	): r extends infer _ ? _ : never
 	<
 		const a,
 		const b,
-		r = Type<inferIntersection<type.infer<a>, type.infer<b>>, $>
+		r = Type<inferIntersection<type.infer<a, $>, type.infer<b, $>>, $>
 	>(
 		a: type.validate<a, $>,
 		b: type.validate<b, $>
@@ -578,7 +579,9 @@ export type NaryIntersectionParser<$> = {
 		const b,
 		const c,
 		r = Type<
-			inferNaryIntersection<[type.infer<a>, type.infer<b>, type.infer<c>]>,
+			inferNaryIntersection<
+				[type.infer<a, $>, type.infer<b, $>, type.infer<c, $>]
+			>,
 			$
 		>
 	>(
@@ -593,7 +596,7 @@ export type NaryIntersectionParser<$> = {
 		const d,
 		r = Type<
 			inferNaryIntersection<
-				[type.infer<a>, type.infer<b>, type.infer<c>, type.infer<d>]
+				[type.infer<a, $>, type.infer<b, $>, type.infer<c, $>, type.infer<d, $>]
 			>,
 			$
 		>
@@ -612,11 +615,11 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>
 				]
 			>,
 			$
@@ -638,12 +641,12 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>
 				]
 			>,
 			$
@@ -667,13 +670,13 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>
 				]
 			>,
 			$
@@ -699,14 +702,14 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>
 				]
 			>,
 			$
@@ -734,15 +737,15 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>
 				]
 			>,
 			$
@@ -772,16 +775,16 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>
 				]
 			>,
 			$
@@ -813,17 +816,17 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>,
+					type.infer<k, $>
 				]
 			>,
 			$
@@ -857,18 +860,18 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>,
+					type.infer<k, $>,
+					type.infer<l, $>
 				]
 			>,
 			$
@@ -904,19 +907,19 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>,
+					type.infer<k, $>,
+					type.infer<l, $>,
+					type.infer<m, $>
 				]
 			>,
 			$
@@ -954,20 +957,20 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>,
+					type.infer<k, $>,
+					type.infer<l, $>,
+					type.infer<m, $>,
+					type.infer<n, $>
 				]
 			>,
 			$
@@ -1007,20 +1010,20 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>,
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>,
+					type.infer<k, $>,
+					type.infer<l, $>,
+					type.infer<m, $>,
+					type.infer<n, $>,
 					type.infer<o>
 				]
 			>,
@@ -1063,22 +1066,22 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>,
-					type.infer<o>,
-					type.infer<p>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>,
+					type.infer<k, $>,
+					type.infer<l, $>,
+					type.infer<m, $>,
+					type.infer<n, $>,
+					type.infer<o, $>,
+					type.infer<p, $>
 				]
 			>,
 			$
@@ -1122,23 +1125,23 @@ export type NaryIntersectionParser<$> = {
 		r = Type<
 			inferNaryIntersection<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>,
-					type.infer<o>,
-					type.infer<p>,
-					type.infer<q>
+					type.infer<a, $>,
+					type.infer<b, $>,
+					type.infer<c, $>,
+					type.infer<d, $>,
+					type.infer<e, $>,
+					type.infer<f, $>,
+					type.infer<g, $>,
+					type.infer<h, $>,
+					type.infer<i, $>,
+					type.infer<j, $>,
+					type.infer<k, $>,
+					type.infer<l, $>,
+					type.infer<m, $>,
+					type.infer<n, $>,
+					type.infer<o, $>,
+					type.infer<p, $>,
+					type.infer<q, $>
 				]
 			>,
 			$
@@ -1165,11 +1168,11 @@ export type NaryIntersectionParser<$> = {
 	<
 		const defs extends readonly unknown[],
 		r = Type<
-			inferNaryIntersection<{ [i in keyof defs]: type.infer<defs[i]> }>,
+			inferNaryIntersection<{ [i in keyof defs]: type.infer<defs[i], $> }>,
 			$
 		>
 	>(
-		...defs: { [i in keyof defs]: type.validate<defs[i]> }
+		...defs: { [i in keyof defs]: type.validate<defs[i], $> }
 	): r extends infer _ ? _ : never
 }
 
@@ -1203,7 +1206,7 @@ export type NaryMergeParser<$> = {
 		inferredA = type.infer<a, $>,
 		inferredB = type.infer<b, $>,
 		inferredC = type.infer<c, $>,
-		r = Type<inferNaryMerge<[type.infer<a>, type.infer<b>, type.infer<c>]>, $>
+		r = Type<inferNaryMerge<[inferredA, inferredB, inferredC]>, $>
 	>(
 		a: type.validate<a, $> &
 			(inferredA extends object ? unknown
@@ -1224,12 +1227,7 @@ export type NaryMergeParser<$> = {
 		inferredB = type.infer<b, $>,
 		inferredC = type.infer<c, $>,
 		inferredD = type.infer<d, $>,
-		r = Type<
-			inferNaryMerge<
-				[type.infer<a>, type.infer<b>, type.infer<c>, type.infer<d>]
-			>,
-			$
-		>
+		r = Type<inferNaryMerge<[inferredA, inferredB, inferredC, inferredD]>, $>
 	>(
 		a: type.validate<a, $> &
 			(inferredA extends object ? unknown
@@ -1256,15 +1254,7 @@ export type NaryMergeParser<$> = {
 		inferredD = type.infer<d, $>,
 		inferredE = type.infer<e, $>,
 		r = Type<
-			inferNaryMerge<
-				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>
-				]
-			>,
+			inferNaryMerge<[inferredA, inferredB, inferredC, inferredD, inferredE]>,
 			$
 		>
 	>(
@@ -1299,14 +1289,7 @@ export type NaryMergeParser<$> = {
 		inferredF = type.infer<f, $>,
 		r = Type<
 			inferNaryMerge<
-				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>
-				]
+				[inferredA, inferredB, inferredC, inferredD, inferredE, inferredF]
 			>,
 			$
 		>
@@ -1348,13 +1331,13 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG
 				]
 			>,
 			$
@@ -1402,14 +1385,14 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH
 				]
 			>,
 			$
@@ -1462,15 +1445,15 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI
 				]
 			>,
 			$
@@ -1528,16 +1511,16 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ
 				]
 			>,
 			$
@@ -1600,17 +1583,17 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ,
+					inferredK
 				]
 			>,
 			$
@@ -1678,18 +1661,18 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ,
+					inferredK,
+					inferredL
 				]
 			>,
 			$
@@ -1762,19 +1745,19 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ,
+					inferredK,
+					inferredL,
+					inferredM
 				]
 			>,
 			$
@@ -1852,20 +1835,20 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ,
+					inferredK,
+					inferredL,
+					inferredM,
+					inferredN
 				]
 			>,
 			$
@@ -1948,21 +1931,21 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>,
-					type.infer<o>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ,
+					inferredK,
+					inferredL,
+					inferredM,
+					inferredN,
+					inferredO
 				]
 			>,
 			$
@@ -2050,22 +2033,22 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>,
-					type.infer<o>,
-					type.infer<p>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ,
+					inferredK,
+					inferredL,
+					inferredM,
+					inferredN,
+					inferredO,
+					inferredP
 				]
 			>,
 			$
@@ -2158,23 +2141,23 @@ export type NaryMergeParser<$> = {
 		r = Type<
 			inferNaryMerge<
 				[
-					type.infer<a>,
-					type.infer<b>,
-					type.infer<c>,
-					type.infer<d>,
-					type.infer<e>,
-					type.infer<f>,
-					type.infer<g>,
-					type.infer<h>,
-					type.infer<i>,
-					type.infer<j>,
-					type.infer<k>,
-					type.infer<l>,
-					type.infer<m>,
-					type.infer<n>,
-					type.infer<o>,
-					type.infer<p>,
-					type.infer<q>
+					inferredA,
+					inferredB,
+					inferredC,
+					inferredD,
+					inferredE,
+					inferredF,
+					inferredG,
+					inferredH,
+					inferredI,
+					inferredJ,
+					inferredK,
+					inferredL,
+					inferredM,
+					inferredN,
+					inferredO,
+					inferredP,
+					inferredQ
 				]
 			>,
 			$
@@ -2234,7 +2217,7 @@ export type NaryMergeParser<$> = {
 	): r extends infer _ ? _ : never
 	<
 		const defs extends readonly unknown[],
-		r = Type<inferNaryMerge<{ [i in keyof defs]: type.infer<defs[i]> }>, $>
+		r = Type<inferNaryMerge<{ [i in keyof defs]: type.infer<defs[i], $> }>, $>
 	>(
 		...defs: {
 			[i in keyof defs]: type.validate<defs[i]> &


### PR DESCRIPTION
fixes: #1422 
- Added scope `$` to all nary type inference. 
- added n-ary (1-16) with scope tests and added normal n-ary test variants (1-16) where possible
