### PR TITLE
docs: add JetBrains IDE plugin

### DIFF
--- a/ark/docs/content/docs/intro/setup.mdx
+++ b/ark/docs/content/docs/intro/setup.mdx
@@ -40,6 +40,11 @@ Without it, your definitions can still feel like a natural extension of the lang
 
 With it, you'll forget there was ever a boundary in the first place.
 
+## JetBrains IDEs
+
+### Extension (optional)
+[ArkType](https://plugins.jetbrains.com/plugin/27099-arktype) provides the embedded syntax highlighting you are familiar with for typescript types.
+
 ## Other editors
 
 If you're using a different editor, we'd love [help adding support](https://github.com/arktypeio/arktype/issues/989). In the meantime, don't worry- ArkType still offers best-in-class DX anywhere TypeScript is supported.


### PR DESCRIPTION
The JetBrains IDE plugin as of now already offers similar syntax highlighting to the VsCode plugin.
There are also more features planned around code completion suggestions, go to definition for type aliases and quick docs.
