### PR TITLE
Re-enable jit for @ark/json-schema

### DIFF
--- a/ark/json-schema/package.json
+++ b/ark/json-schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/json-schema",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"license": "MIT",
 	"authors": [
 		{

--- a/ark/json-schema/scope.ts
+++ b/ark/json-schema/scope.ts
@@ -105,7 +105,6 @@ const $: JsonSchemaScope = scope(
 			type: "'string'"
 		}
 	},
-	{ jitless: true } // workaround for https://github.com/arktypeio/arktype/issues/1188
 ) as never
 
 export const JsonSchemaScope = $.export()


### PR DESCRIPTION
This PR enables jit for `@ark/json-schema`

It was previously disabled during development as a workaround for #1188, but that has now been solved.

I've confirmed that the library works with jit by adding a temporary script and running it & also by running the `@ark/json-schema` unit tests.
