### PR TITLE
docs: fix wrongly capitalized variable in branded docs

### DIFF
--- a/ark/docs/content/docs/expressions/index.mdx
+++ b/ark/docs/content/docs/expressions/index.mdx
@@ -197,7 +197,7 @@ Add a type-only symbol to an existing type so that the only values that satisfy 
 
 ```ts
 // @noErrors
-const Even = type("(number % 2)#even")
+const even = type("(number % 2)#even")
 type Even = typeof even.infer
 
 const good: Even = even.assert(2)


### PR DESCRIPTION
Instead of `even` its `Even` in one of the two examples, which results in the later usage infering as `any`; confused me a couple of times already :D