### PR TITLE
fix docs popover

### DIFF
--- a/ark/docs/app/global.css
+++ b/ark/docs/app/global.css
@@ -87,7 +87,7 @@ code {
 	}
 }
 
-.fd-codeblock {
+.fd-codeblock.twoslash {
 	border-radius: 1.5rem !important;
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

Before:
<img width="174" height="121" alt="image" src="https://github.com/user-attachments/assets/2e6e2923-a462-44a3-8b0d-3205c65863b2" />

After:
<img width="153" height="123" alt="image" src="https://github.com/user-attachments/assets/8c09ef5f-23fd-4684-a6d6-123c8ea69013" />

