### PR TITLE
docs: fix spelling errors in comments and variable references

### DIFF
--- a/ark/json-schema/object.ts
+++ b/ark/json-schema/object.ts
@@ -73,7 +73,7 @@ const parsePatternProperties = (jsonSchema: JsonSchema.Object) => {
 		([key, value]) => [new RegExp(key), jsonSchemaToType(value)] as const
 	)
 
-	// NB: We don't validate compatability of schemas for overlapping patternProperties
+	// NB: We don't validate compatibility of schemas for overlapping patternProperties
 	// since getting the intersection of regexes is inherently non-trivial.
 	const indexSchemas = patternProperties.map(
 		([pattern, parsedPatternPropertySchema]) => ({

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -245,7 +245,7 @@ const Base = type({
 
 // accepts ...definitions
 const intersection = type.and(
-	base,
+	Base,
 	{
 		bar: "number"
 	},
@@ -264,7 +264,7 @@ const Base = type({
 
 // accepts ...objectDefinitions
 const merged = type.merge(
-	base,
+	Base,
 	{
 		"[string]": "bigint",
 		"foo?": "1n"

--- a/ark/type/__tests__/imports.test.ts
+++ b/ark/type/__tests__/imports.test.ts
@@ -264,7 +264,7 @@ contextualize(() => {
 		).throwsAndHasTypeError(writePrefixedPrivateReferenceMessage("kekw"))
 	})
 
-	it("errors on public and private refrence with same name", () => {
+	it("errors on public and private reference with same name", () => {
 		attest(() =>
 			scope({
 				kekw: "1",

--- a/ark/type/parser/objectLiteral.ts
+++ b/ark/type/parser/objectLiteral.ts
@@ -234,7 +234,7 @@ type nonOptionalKeyFromEntry<k extends PropertyKey, v, $, args> =
 			:	parsedKey["normalized"]
 		: parsedKey extends PreparsedEntryKey<"index"> ?
 			inferDefinition<parsedKey["normalized"], $, args> & Key
-		:	// optional keys are not included by defintion
+		:	// optional keys are not included by definition
 			// "..." is handled at the type root so is handled neither here nor in optionalKeyFrom
 			// "+" has no effect on inference
 			never

--- a/ark/util/arrays.ts
+++ b/ark/util/arrays.ts
@@ -25,19 +25,19 @@ type DuplicateData<val = unknown> = { element: val; indices: number[] }
 			isEqual(duplicate.element, element)
 		)
 		if (duplicatesIndx !== -1) {
-			// This is at least the third occurence of an item equal to `element`,
+			// This is at least the third occurrence of an item equal to `element`,
 			// so add this index to the list of indices where the element is duplicated.
 			duplicates[duplicatesIndx].indices.push(indx)
 			continue
 		}
 
 		// At this point, we know this is either the first
-		// or second occurence of an item equal to `element`...
+		// or second occurrence of an item equal to `element`...
 
 		let found = false
 		for (const [existingElement, firstSeenIndx] of elementFirstSeenIndx) {
 			if (isEqual(element, existingElement)) {
-				// This is the second occurence of an item equal to `element`,
+				// This is the second occurrence of an item equal to `element`,
 				// so store it as a duplicate.
 				found = true
 				duplicates.push({


### PR DESCRIPTION
- Fix "occurence" → "occurrence" in ark/util/arrays.ts comments (3 instances)
- Fix "refrence" → "reference" in test name (ark/type/__tests__/imports.test.ts)
- Fix "defintion" → "definition" in comment (ark/type/parser/objectLiteral.ts)
- Fix "compatability" → "compatibility" in comment (ark/json-schema/object.ts)
- Fix variable name consistency "base" → "Base" in CHANGELOG.md examples (2 instances)

<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
