### PR TITLE
fix declare type issue (#1578)

### DIFF
--- a/ark/type/__tests__/declared.test.ts
+++ b/ark/type/__tests__/declared.test.ts
@@ -1,5 +1,5 @@
 import { attest, contextualize } from "@ark/attest"
-import { declare, type } from "arktype"
+import { declare, type, type Out } from "arktype"
 import { incompleteArrayTokenMessage } from "arktype/internal/parser/shift/operator/operator.ts"
 
 contextualize(() => {
@@ -249,9 +249,9 @@ contextualize(() => {
 			"b?": "number"
 		})
 
-		attest<(In: { a: string; b?: number }) => Expected>(T.t).type.toString.snap(
-			"(In: { a: string; b?: number }) => Expected"
-		)
+		attest<(In: { a: string; b?: number }) => Out<Expected>>(
+			T.t
+		).type.toString.snap("(In: { a: string; b?: number }) => Out<Expected>")
 	})
 
 	it("morph out mismatch", () => {

--- a/ark/type/declare.ts
+++ b/ark/type/declare.ts
@@ -9,7 +9,7 @@ import type {
 	show,
 	unset
 } from "@ark/util"
-import type { distill } from "./attributes.ts"
+import type { distill, Out } from "./attributes.ts"
 import type { type } from "./keywords/keywords.ts"
 import type {
 	inferDefinition,
@@ -38,7 +38,7 @@ type finalizePreinferred<preinferred, def, $, ctx extends DeclareContext> =
 	ctx["side"] extends distill.Side ?
 		ctx["side"] extends "in" ?
 			(In: preinferred) => type.infer.Out<def, $>
-		:	(In: type.infer.In<def, $>) => preinferred
+		:	(In: type.infer.In<def, $>) => Out<preinferred>
 	:	preinferred
 
 export type DeclareContext = {


### PR DESCRIPTION
Looks like it was supposed to be wrapped in Out<> and the Type now correctly matches the same behavior as using type() without declare. Fixes issue #1578.