### PR TITLE
chore: use "add" instead of "install" for Bun command

### DIFF
--- a/ark/docs/components/InstallationTabs.tsx
+++ b/ark/docs/components/InstallationTabs.tsx
@@ -11,7 +11,7 @@ type InstallationTabProps = {
 
 const InstallerTab = ({ name }: InstallationTabProps) => (
 	<Tab value={name} className="installer-tab">
-		<CodeBlock lang="bash">{`${name} ${name === "yarn" ? "add" : "install"} arktype`}</CodeBlock>
+		<CodeBlock lang="bash">{`${name} ${name === "yarn" || name === "bun" ? "add" : "install"} arktype`}</CodeBlock>
 	</Tab>
 )
 


### PR DESCRIPTION
while `bun install <package>` technically works, `bun add <package>` is much more ergonomic for people using Bun.

<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->
