### PR TITLE
fix: allow prototype method names as object keys

### DIFF
--- a/ark/schema/structure/structure.ts
+++ b/ark/schema/structure/structure.ts
@@ -336,7 +336,7 @@ const implementation: nodeImplementationOf<Structure.Declaration> =
 		reduce: (inner, $) => {
 			if (!inner.required && !inner.optional) return
 
-			const seen: Record<Key, true | undefined> = {}
+			const seen: Record<Key, true | undefined> = Object.create(null)
 			let updated = false
 			const newOptionalProps: OptionalNode[] =
 				inner.optional ? [...inner.optional] : []

--- a/ark/type/__tests__/objects/props.test.ts
+++ b/ark/type/__tests__/objects/props.test.ts
@@ -94,4 +94,20 @@ contextualize(() => {
 			})
 		).throws(writeDuplicateKeyMessage("a"))
 	})
+
+	it("allows prototype method names as keys", () => {
+		// constructor, hasOwnProperty, toString, etc. are valid object keys
+		// and should not be incorrectly flagged as duplicates
+		const T = type({
+			constructor: "string",
+			hasOwnProperty: "number",
+			toString: "boolean"
+		})
+
+		attest<{
+			constructor: string
+			hasOwnProperty: number
+			toString: boolean
+		}>(T.t)
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #1572

Object.prototype method names like `constructor`, `hasOwnProperty`, and `toString` are valid object keys and should not be incorrectly flagged as duplicate keys.

## Problem

When defining an object type with a key that matches an `Object.prototype` method name:

```ts
type({ constructor: "string" })
```

This throws a `ParseError: Duplicate key "constructor"` even though the key is valid.

## Root Cause

The `seen` object used for duplicate key detection was initialized with `{}`, which inherits from `Object.prototype`. When checking `key in seen`, it returned `true` for keys like `"constructor"` because they exist on the prototype chain.

## Solution

Use `Object.create(null)` to create a prototype-free object for the `seen` tracking. This ensures only explicitly set keys are detected as duplicates.

## Testing

Added a test case to verify that prototype method names can be used as object keys without error.