### PR TITLE
fix(type): anchor UUID #versioned regex to reject partial matches

### DIFF
--- a/ark/type/__tests__/keywords/uuid.test.ts
+++ b/ark/type/__tests__/keywords/uuid.test.ts
@@ -24,4 +24,14 @@ contextualize(() => {
 			'must be a UUIDv4 (was "f70b8242-dd57-5e6b-b0b7-649d997140a0")'
 		)
 	})
+
+	it("rejects partial matches", () => {
+		const Uuid = type("string.uuid")
+		attest(
+			Uuid("dbb1e8e0-40fc-4c14-87eb-61b25d166a1b extra").toString()
+		).snap('must be a UUID (was "dbb1e8e0-40fc-4c14-87eb-61b25d166a1b extra")')
+		attest(
+			Uuid("prefix dbb1e8e0-40fc-4c14-87eb-61b25d166a1b").toString()
+		).snap('must be a UUID (was "prefix dbb1e8e0-40fc-4c14-87eb-61b25d166a1b")')
+	})
 })

--- a/ark/type/__tests__/keywords/uuid.test.ts
+++ b/ark/type/__tests__/keywords/uuid.test.ts
@@ -27,11 +27,11 @@ contextualize(() => {
 
 	it("rejects partial matches", () => {
 		const Uuid = type("string.uuid")
-		attest(
-			Uuid("dbb1e8e0-40fc-4c14-87eb-61b25d166a1b extra").toString()
-		).snap('must be a UUID (was "dbb1e8e0-40fc-4c14-87eb-61b25d166a1b extra")')
-		attest(
-			Uuid("prefix dbb1e8e0-40fc-4c14-87eb-61b25d166a1b").toString()
-		).snap('must be a UUID (was "prefix dbb1e8e0-40fc-4c14-87eb-61b25d166a1b")')
+		attest(Uuid("dbb1e8e0-40fc-4c14-87eb-61b25d166a1b extra").toString()).snap(
+			'must be a UUID (was "dbb1e8e0-40fc-4c14-87eb-61b25d166a1b extra")'
+		)
+		attest(Uuid("prefix dbb1e8e0-40fc-4c14-87eb-61b25d166a1b").toString()).snap(
+			'must be a UUID (was "prefix dbb1e8e0-40fc-4c14-87eb-61b25d166a1b")'
+		)
 	})
 })

--- a/ark/type/keywords/string.ts
+++ b/ark/type/keywords/string.ts
@@ -841,7 +841,7 @@ export const uuid = Scope.module(
 		"#nil": "'00000000-0000-0000-0000-000000000000'",
 		"#max": "'ffffffff-ffff-ffff-ffff-ffffffffffff'",
 		"#versioned":
-			/[\da-f]{8}-[\da-f]{4}-[1-8][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}/i,
+			/^[\da-f]{8}-[\da-f]{4}-[1-8][\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i,
 		v1: regexStringNode(
 			/^[\da-f]{8}-[\da-f]{4}-1[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i,
 			"a UUIDv1"


### PR DESCRIPTION
## Summary

Fixes #1601

The `#versioned` private regex in the UUID `Scope.module` was missing `^` and `$` anchors, causing `type("string.uuid")` to accept strings that merely *contain* a UUID substring (e.g. `"dbb1e8e0-...1b extra stuff"`).

All individual version regexes (`v1`–`v8`) already used anchored patterns via `regexStringNode()` — only `#versioned` was missing them.

- Added `^`/`$` anchors to the `#versioned` regex
- Added regression test for trailing and leading content rejection

## Test plan

- [x] Existing UUID tests pass
- [x] New `"rejects partial matches"` test verifies both trailing and leading content
- [x] `pnpm prChecks` passes (format, lint, typecheck, full test suite)