### PR TITLE
fix(util): format collapsibleDate time without locale dependency

### DIFF
--- a/ark/util/serialize.ts
+++ b/ark/util/serialize.ts
@@ -203,18 +203,15 @@ export const describeCollapsibleDate = (date: Date): string => {
 	if (hours === 0 && minutes === 0 && seconds === 0 && milliseconds === 0)
 		return datePortion
 
-	let timePortion = date.toLocaleTimeString()
+	const h = hours % 12 || 12
+	const suffix = hours < 12 ? " AM" : " PM"
 
-	const suffix =
-		timePortion.endsWith(" AM") || timePortion.endsWith(" PM") ?
-			timePortion.slice(-3)
-		:	""
-
-	if (suffix) timePortion = timePortion.slice(0, -suffix.length)
+	let timePortion =
+		seconds || milliseconds ?
+			`${h}:${pad(minutes, 2)}:${pad(seconds, 2)}`
+		:	`${h}:${pad(minutes, 2)}`
 
 	if (milliseconds) timePortion += `.${pad(milliseconds, 3)}`
-	else if (timeWithUnnecessarySeconds.test(timePortion))
-		timePortion = timePortion.slice(0, -3)
 
 	return `${timePortion + suffix}, ${datePortion}`
 }

--- a/ark/util/serialize.ts
+++ b/ark/util/serialize.ts
@@ -231,7 +231,5 @@ const months = [
 	"December"
 ]
 
-const timeWithUnnecessarySeconds = /:\d\d:00$/
-
 const pad = (value: number, length: number) =>
 	String(value).padStart(length, "0")


### PR DESCRIPTION
## Summary

Fixes #1494

`describeCollapsibleDate()` called `date.toLocaleTimeString()` which produces 24-hour format on non-US systems, causing garbled output like `"14:30, January 15, 2023"` instead of `"2:30 PM, January 15, 2023"`.

Replaced with locale-independent manual formatting using `getHours()`, `getMinutes()`, `getSeconds()`:
- `hours % 12 || 12` for correct 12-hour conversion (midnight→12, noon→12)
- `hours < 12 ? " AM" : " PM"` for suffix
- Reuses existing `pad()` helper
- Removed now-unused `timeWithUnnecessarySeconds` regex (caught by eslint `no-unused-vars`)

## Test plan

- [x] All 8 existing `collapsibleDate` tests pass unchanged (year-only, day, minutes, seconds, milliseconds, midnight, noon, AM/PM)
- [x] Verified all edge cases: midnight (h=0→12 AM), noon (h=12→12 PM), hour boundaries
- [x] `pnpm prChecks` passes (format, lint, typecheck, full test suite)