### PR TITLE
feat(type): add string.base58 built-in validator

### DIFF
--- a/ark/type/__tests__/integration/allConfig.ts
+++ b/ark/type/__tests__/integration/allConfig.ts
@@ -107,6 +107,9 @@ configure({
 		"string.hex": {
 			description: "configured"
 		},
+		"string.base58": {
+			description: "configured"
+		},
 		"string.base64.url": {
 			description: "configured"
 		},

--- a/ark/type/__tests__/keywords/string.test.ts
+++ b/ark/type/__tests__/keywords/string.test.ts
@@ -43,9 +43,7 @@ contextualize(() => {
 		attest(Base58("invalid0OIl").toString()).snap(
 			'must be base58-encoded (was "invalid0OIl")'
 		)
-		attest(Base58("").toString()).snap(
-			'must be base58-encoded (was "")'
-		)
+		attest(Base58("").toString()).snap('must be base58-encoded (was "")')
 	})
 
 	it("base64", () => {

--- a/ark/type/__tests__/keywords/string.test.ts
+++ b/ark/type/__tests__/keywords/string.test.ts
@@ -40,9 +40,10 @@ contextualize(() => {
 			"5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"
 		)
 		attest(Base58("abc123")).snap("abc123")
-		attest(Base58("invalid0OIl").toString()).snap(
-			'must be base58-encoded (was "invalid0OIl")'
-		)
+		attest(Base58("0").toString()).snap('must be base58-encoded (was "0")')
+		attest(Base58("O").toString()).snap('must be base58-encoded (was "O")')
+		attest(Base58("I").toString()).snap('must be base58-encoded (was "I")')
+		attest(Base58("l").toString()).snap('must be base58-encoded (was "l")')
 		attest(Base58("").toString()).snap('must be base58-encoded (was "")')
 	})
 

--- a/ark/type/__tests__/keywords/string.test.ts
+++ b/ark/type/__tests__/keywords/string.test.ts
@@ -34,6 +34,20 @@ contextualize(() => {
 		)
 	})
 
+	it("base58", () => {
+		const Base58 = type("string.base58")
+		attest(Base58("5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ")).snap(
+			"5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"
+		)
+		attest(Base58("abc123")).snap("abc123")
+		attest(Base58("invalid0OIl").toString()).snap(
+			'must be base58-encoded (was "invalid0OIl")'
+		)
+		attest(Base58("").toString()).snap(
+			'must be base58-encoded (was "")'
+		)
+	})
+
 	it("base64", () => {
 		const B64 = type("string.base64")
 		attest(B64("fn5+")).snap("fn5+")

--- a/ark/type/keywords/string.ts
+++ b/ark/type/keywords/string.ts
@@ -80,6 +80,8 @@ export declare namespace stringInteger {
 
 const hex = regexStringNode(/^[\dA-Fa-f]+$/, "hex characters only")
 
+const base58 = regexStringNode(/^[1-9A-HJ-NP-Za-km-z]+$/, "base58-encoded")
+
 const base64 = Scope.module(
 	{
 		root: regexStringNode(
@@ -911,6 +913,7 @@ export const string = Scope.module(
 			"only letters and digits 0-9"
 		),
 		hex,
+		base58,
 		base64,
 		capitalize,
 		creditCard,
@@ -945,6 +948,7 @@ export declare namespace string {
 		alpha: string
 		alphanumeric: string
 		hex: string
+		base58: string
 		base64: base64.submodule
 		capitalize: capitalize.submodule
 		creditCard: string


### PR DESCRIPTION
## Summary

Closes #1520

Adds `string.base58` as a built-in string validator following the existing `hex` pattern.

**Base58 alphabet** (per [IETF draft](https://datatracker.ietf.org/doc/html/draft-msporny-base58-03) and [Bitcoin spec](https://en.bitcoin.it/wiki/Base58Check_encoding)):
`123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`
Excludes: `0` (zero), `O` (capital o), `I` (capital i), `l` (lowercase L)

- Regex: `/^[1-9A-HJ-NP-Za-km-z]+$/` (uses `+` like `hex`, rejects empty strings)
- Registered via `regexStringNode()`, added to `Scope.module` and namespace `$` type
- Tests individually verify each excluded character (`0`, `O`, `I`, `l`)

> Note: the issue's suggested regex used `\d` which includes `0` — corrected to `1-9`.

## Test plan

- [x] Valid Base58 strings (Bitcoin address format, simple alphanumeric) accepted
- [x] Each excluded character rejected individually
- [x] Empty string rejected
- [x] `pnpm prChecks` passes (format, lint, typecheck, full test suite)