### PR TITLE
fix(type): add number.finite keyword to reject Infinity and NaN

### DIFF
--- a/ark/type/__tests__/integration/allConfig.ts
+++ b/ark/type/__tests__/integration/allConfig.ts
@@ -1,258 +1,258 @@
 import { configure } from "arktype/config"
 
 configure({
-	keywords: {
-		bigint: {
-			description: "configured"
-		},
-		boolean: {
-			description: "configured"
-		},
-		false: {
-			description: "configured"
-		},
-		never: {
-			description: "configured"
-		},
-		null: {
-			description: "configured"
-		},
-		symbol: {
-			description: "configured"
-		},
-		true: {
-			description: "configured"
-		},
-		undefined: {
-			description: "configured"
-		},
-		Date: {
-			description: "configured"
-		},
-		Error: {
-			description: "configured"
-		},
-		Function: {
-			description: "configured"
-		},
-		Map: {
-			description: "configured"
-		},
-		Promise: {
-			description: "configured"
-		},
-		RegExp: {
-			description: "configured"
-		},
-		Set: {
-			description: "configured"
-		},
-		WeakMap: {
-			description: "configured"
-		},
-		WeakSet: {
-			description: "configured"
-		},
-		ArrayBuffer: {
-			description: "configured"
-		},
-		Blob: {
-			description: "configured"
-		},
-		File: {
-			description: "configured"
-		},
-		Headers: {
-			description: "configured"
-		},
-		Request: {
-			description: "configured"
-		},
-		Response: {
-			description: "configured"
-		},
-		URL: {
-			description: "configured"
-		},
-		Key: {
-			description: "configured"
-		},
-		"number.integer": {
-			description: "configured"
-		},
-		"number.epoch": {
-			description: "configured"
-		},
-		"number.safe": {
-			description: "configured"
-		},
-		"number.finite": {
-			description: "configured"
-		},
-		"number.NaN": {
-			description: "configured"
-		},
-		"number.Infinity": {
-			description: "configured"
-		},
-		"number.NegativeInfinity": {
-			description: "configured"
-		},
-		"object.json.stringify": {
-			description: "configured"
-		},
-		"string.alpha": {
-			description: "configured"
-		},
-		"string.alphanumeric": {
-			description: "configured"
-		},
-		"string.hex": {
-			description: "configured"
-		},
-		"string.base64.url": {
-			description: "configured"
-		},
-		"string.capitalize.preformatted": {
-			description: "configured"
-		},
-		"string.creditCard": {
-			description: "configured"
-		},
-		"string.date.parse": {
-			description: "configured"
-		},
-		"string.date.iso.parse": {
-			description: "configured"
-		},
-		"string.date.epoch.parse": {
-			description: "configured"
-		},
-		"string.digits": {
-			description: "configured"
-		},
-		"string.email": {
-			description: "configured"
-		},
-		"string.integer.parse": {
-			description: "configured"
-		},
-		"string.ip.v4": {
-			description: "configured"
-		},
-		"string.ip.v6": {
-			description: "configured"
-		},
-		"string.json.parse": {
-			description: "configured"
-		},
-		"string.lower.preformatted": {
-			description: "configured"
-		},
-		"string.normalize.NFC.preformatted": {
-			description: "configured"
-		},
-		"string.normalize.NFD.preformatted": {
-			description: "configured"
-		},
-		"string.normalize.NFKC.preformatted": {
-			description: "configured"
-		},
-		"string.normalize.NFKD.preformatted": {
-			description: "configured"
-		},
-		"string.numeric.parse": {
-			description: "configured"
-		},
-		"string.regex": {
-			description: "configured"
-		},
-		"string.semver": {
-			description: "configured"
-		},
-		"string.trim.preformatted": {
-			description: "configured"
-		},
-		"string.upper.preformatted": {
-			description: "configured"
-		},
-		"string.url.parse": {
-			description: "configured"
-		},
-		"string.uuid.v1": {
-			description: "configured"
-		},
-		"string.uuid.v2": {
-			description: "configured"
-		},
-		"string.uuid.v3": {
-			description: "configured"
-		},
-		"string.uuid.v4": {
-			description: "configured"
-		},
-		"string.uuid.v5": {
-			description: "configured"
-		},
-		"string.uuid.v6": {
-			description: "configured"
-		},
-		"string.uuid.v7": {
-			description: "configured"
-		},
-		"string.uuid.v8": {
-			description: "configured"
-		},
-		"unknown.any": {
-			description: "configured"
-		},
-		"Array.readonly": {
-			description: "configured"
-		},
-		"Array.index": {
-			description: "configured"
-		},
-		"FormData.value": {
-			description: "configured"
-		},
-		"FormData.parsed": {
-			description: "configured"
-		},
-		"FormData.parse": {
-			description: "configured"
-		},
-		"TypedArray.Int8": {
-			description: "configured"
-		},
-		"TypedArray.Uint8": {
-			description: "configured"
-		},
-		"TypedArray.Uint8Clamped": {
-			description: "configured"
-		},
-		"TypedArray.Int16": {
-			description: "configured"
-		},
-		"TypedArray.Uint16": {
-			description: "configured"
-		},
-		"TypedArray.Int32": {
-			description: "configured"
-		},
-		"TypedArray.Uint32": {
-			description: "configured"
-		},
-		"TypedArray.Float32": {
-			description: "configured"
-		},
-		"TypedArray.Float64": {
-			description: "configured"
-		},
-		"TypedArray.BigInt64": {
-			description: "configured"
-		},
-		"TypedArray.BigUint64": {
-			description: "configured"
-		}
-	}
+    "keywords": {
+        "bigint": {
+            "description": "configured"
+        },
+        "boolean": {
+            "description": "configured"
+        },
+        "false": {
+            "description": "configured"
+        },
+        "never": {
+            "description": "configured"
+        },
+        "null": {
+            "description": "configured"
+        },
+        "symbol": {
+            "description": "configured"
+        },
+        "true": {
+            "description": "configured"
+        },
+        "undefined": {
+            "description": "configured"
+        },
+        "Date": {
+            "description": "configured"
+        },
+        "Error": {
+            "description": "configured"
+        },
+        "Function": {
+            "description": "configured"
+        },
+        "Map": {
+            "description": "configured"
+        },
+        "Promise": {
+            "description": "configured"
+        },
+        "RegExp": {
+            "description": "configured"
+        },
+        "Set": {
+            "description": "configured"
+        },
+        "WeakMap": {
+            "description": "configured"
+        },
+        "WeakSet": {
+            "description": "configured"
+        },
+        "ArrayBuffer": {
+            "description": "configured"
+        },
+        "Blob": {
+            "description": "configured"
+        },
+        "File": {
+            "description": "configured"
+        },
+        "Headers": {
+            "description": "configured"
+        },
+        "Request": {
+            "description": "configured"
+        },
+        "Response": {
+            "description": "configured"
+        },
+        "URL": {
+            "description": "configured"
+        },
+        "Key": {
+            "description": "configured"
+        },
+        "number.integer": {
+            "description": "configured"
+        },
+        "number.epoch": {
+            "description": "configured"
+        },
+        "number.finite": {
+            "description": "configured"
+        },
+        "number.safe": {
+            "description": "configured"
+        },
+        "number.NaN": {
+            "description": "configured"
+        },
+        "number.Infinity": {
+            "description": "configured"
+        },
+        "number.NegativeInfinity": {
+            "description": "configured"
+        },
+        "object.json.stringify": {
+            "description": "configured"
+        },
+        "string.alpha": {
+            "description": "configured"
+        },
+        "string.alphanumeric": {
+            "description": "configured"
+        },
+        "string.hex": {
+            "description": "configured"
+        },
+        "string.base64.url": {
+            "description": "configured"
+        },
+        "string.capitalize.preformatted": {
+            "description": "configured"
+        },
+        "string.creditCard": {
+            "description": "configured"
+        },
+        "string.date.parse": {
+            "description": "configured"
+        },
+        "string.date.iso.parse": {
+            "description": "configured"
+        },
+        "string.date.epoch.parse": {
+            "description": "configured"
+        },
+        "string.digits": {
+            "description": "configured"
+        },
+        "string.email": {
+            "description": "configured"
+        },
+        "string.integer.parse": {
+            "description": "configured"
+        },
+        "string.ip.v4": {
+            "description": "configured"
+        },
+        "string.ip.v6": {
+            "description": "configured"
+        },
+        "string.json.parse": {
+            "description": "configured"
+        },
+        "string.lower.preformatted": {
+            "description": "configured"
+        },
+        "string.normalize.NFC.preformatted": {
+            "description": "configured"
+        },
+        "string.normalize.NFD.preformatted": {
+            "description": "configured"
+        },
+        "string.normalize.NFKC.preformatted": {
+            "description": "configured"
+        },
+        "string.normalize.NFKD.preformatted": {
+            "description": "configured"
+        },
+        "string.numeric.parse": {
+            "description": "configured"
+        },
+        "string.regex": {
+            "description": "configured"
+        },
+        "string.semver": {
+            "description": "configured"
+        },
+        "string.trim.preformatted": {
+            "description": "configured"
+        },
+        "string.upper.preformatted": {
+            "description": "configured"
+        },
+        "string.url.parse": {
+            "description": "configured"
+        },
+        "string.uuid.v1": {
+            "description": "configured"
+        },
+        "string.uuid.v2": {
+            "description": "configured"
+        },
+        "string.uuid.v3": {
+            "description": "configured"
+        },
+        "string.uuid.v4": {
+            "description": "configured"
+        },
+        "string.uuid.v5": {
+            "description": "configured"
+        },
+        "string.uuid.v6": {
+            "description": "configured"
+        },
+        "string.uuid.v7": {
+            "description": "configured"
+        },
+        "string.uuid.v8": {
+            "description": "configured"
+        },
+        "unknown.any": {
+            "description": "configured"
+        },
+        "Array.readonly": {
+            "description": "configured"
+        },
+        "Array.index": {
+            "description": "configured"
+        },
+        "FormData.value": {
+            "description": "configured"
+        },
+        "FormData.parsed": {
+            "description": "configured"
+        },
+        "FormData.parse": {
+            "description": "configured"
+        },
+        "TypedArray.Int8": {
+            "description": "configured"
+        },
+        "TypedArray.Uint8": {
+            "description": "configured"
+        },
+        "TypedArray.Uint8Clamped": {
+            "description": "configured"
+        },
+        "TypedArray.Int16": {
+            "description": "configured"
+        },
+        "TypedArray.Uint16": {
+            "description": "configured"
+        },
+        "TypedArray.Int32": {
+            "description": "configured"
+        },
+        "TypedArray.Uint32": {
+            "description": "configured"
+        },
+        "TypedArray.Float32": {
+            "description": "configured"
+        },
+        "TypedArray.Float64": {
+            "description": "configured"
+        },
+        "TypedArray.BigInt64": {
+            "description": "configured"
+        },
+        "TypedArray.BigUint64": {
+            "description": "configured"
+        }
+    }
 })

--- a/ark/type/__tests__/integration/allConfig.ts
+++ b/ark/type/__tests__/integration/allConfig.ts
@@ -86,6 +86,9 @@ configure({
 		"number.safe": {
 			description: "configured"
 		},
+		"number.finite": {
+			description: "configured"
+		},
 		"number.NaN": {
 			description: "configured"
 		},

--- a/ark/type/__tests__/integration/allConfig.ts
+++ b/ark/type/__tests__/integration/allConfig.ts
@@ -1,258 +1,258 @@
 import { configure } from "arktype/config"
 
 configure({
-    "keywords": {
-        "bigint": {
-            "description": "configured"
-        },
-        "boolean": {
-            "description": "configured"
-        },
-        "false": {
-            "description": "configured"
-        },
-        "never": {
-            "description": "configured"
-        },
-        "null": {
-            "description": "configured"
-        },
-        "symbol": {
-            "description": "configured"
-        },
-        "true": {
-            "description": "configured"
-        },
-        "undefined": {
-            "description": "configured"
-        },
-        "Date": {
-            "description": "configured"
-        },
-        "Error": {
-            "description": "configured"
-        },
-        "Function": {
-            "description": "configured"
-        },
-        "Map": {
-            "description": "configured"
-        },
-        "Promise": {
-            "description": "configured"
-        },
-        "RegExp": {
-            "description": "configured"
-        },
-        "Set": {
-            "description": "configured"
-        },
-        "WeakMap": {
-            "description": "configured"
-        },
-        "WeakSet": {
-            "description": "configured"
-        },
-        "ArrayBuffer": {
-            "description": "configured"
-        },
-        "Blob": {
-            "description": "configured"
-        },
-        "File": {
-            "description": "configured"
-        },
-        "Headers": {
-            "description": "configured"
-        },
-        "Request": {
-            "description": "configured"
-        },
-        "Response": {
-            "description": "configured"
-        },
-        "URL": {
-            "description": "configured"
-        },
-        "Key": {
-            "description": "configured"
-        },
-        "number.integer": {
-            "description": "configured"
-        },
-        "number.epoch": {
-            "description": "configured"
-        },
-        "number.finite": {
-            "description": "configured"
-        },
-        "number.safe": {
-            "description": "configured"
-        },
-        "number.NaN": {
-            "description": "configured"
-        },
-        "number.Infinity": {
-            "description": "configured"
-        },
-        "number.NegativeInfinity": {
-            "description": "configured"
-        },
-        "object.json.stringify": {
-            "description": "configured"
-        },
-        "string.alpha": {
-            "description": "configured"
-        },
-        "string.alphanumeric": {
-            "description": "configured"
-        },
-        "string.hex": {
-            "description": "configured"
-        },
-        "string.base64.url": {
-            "description": "configured"
-        },
-        "string.capitalize.preformatted": {
-            "description": "configured"
-        },
-        "string.creditCard": {
-            "description": "configured"
-        },
-        "string.date.parse": {
-            "description": "configured"
-        },
-        "string.date.iso.parse": {
-            "description": "configured"
-        },
-        "string.date.epoch.parse": {
-            "description": "configured"
-        },
-        "string.digits": {
-            "description": "configured"
-        },
-        "string.email": {
-            "description": "configured"
-        },
-        "string.integer.parse": {
-            "description": "configured"
-        },
-        "string.ip.v4": {
-            "description": "configured"
-        },
-        "string.ip.v6": {
-            "description": "configured"
-        },
-        "string.json.parse": {
-            "description": "configured"
-        },
-        "string.lower.preformatted": {
-            "description": "configured"
-        },
-        "string.normalize.NFC.preformatted": {
-            "description": "configured"
-        },
-        "string.normalize.NFD.preformatted": {
-            "description": "configured"
-        },
-        "string.normalize.NFKC.preformatted": {
-            "description": "configured"
-        },
-        "string.normalize.NFKD.preformatted": {
-            "description": "configured"
-        },
-        "string.numeric.parse": {
-            "description": "configured"
-        },
-        "string.regex": {
-            "description": "configured"
-        },
-        "string.semver": {
-            "description": "configured"
-        },
-        "string.trim.preformatted": {
-            "description": "configured"
-        },
-        "string.upper.preformatted": {
-            "description": "configured"
-        },
-        "string.url.parse": {
-            "description": "configured"
-        },
-        "string.uuid.v1": {
-            "description": "configured"
-        },
-        "string.uuid.v2": {
-            "description": "configured"
-        },
-        "string.uuid.v3": {
-            "description": "configured"
-        },
-        "string.uuid.v4": {
-            "description": "configured"
-        },
-        "string.uuid.v5": {
-            "description": "configured"
-        },
-        "string.uuid.v6": {
-            "description": "configured"
-        },
-        "string.uuid.v7": {
-            "description": "configured"
-        },
-        "string.uuid.v8": {
-            "description": "configured"
-        },
-        "unknown.any": {
-            "description": "configured"
-        },
-        "Array.readonly": {
-            "description": "configured"
-        },
-        "Array.index": {
-            "description": "configured"
-        },
-        "FormData.value": {
-            "description": "configured"
-        },
-        "FormData.parsed": {
-            "description": "configured"
-        },
-        "FormData.parse": {
-            "description": "configured"
-        },
-        "TypedArray.Int8": {
-            "description": "configured"
-        },
-        "TypedArray.Uint8": {
-            "description": "configured"
-        },
-        "TypedArray.Uint8Clamped": {
-            "description": "configured"
-        },
-        "TypedArray.Int16": {
-            "description": "configured"
-        },
-        "TypedArray.Uint16": {
-            "description": "configured"
-        },
-        "TypedArray.Int32": {
-            "description": "configured"
-        },
-        "TypedArray.Uint32": {
-            "description": "configured"
-        },
-        "TypedArray.Float32": {
-            "description": "configured"
-        },
-        "TypedArray.Float64": {
-            "description": "configured"
-        },
-        "TypedArray.BigInt64": {
-            "description": "configured"
-        },
-        "TypedArray.BigUint64": {
-            "description": "configured"
-        }
-    }
+	keywords: {
+		bigint: {
+			description: "configured"
+		},
+		boolean: {
+			description: "configured"
+		},
+		false: {
+			description: "configured"
+		},
+		never: {
+			description: "configured"
+		},
+		null: {
+			description: "configured"
+		},
+		symbol: {
+			description: "configured"
+		},
+		true: {
+			description: "configured"
+		},
+		undefined: {
+			description: "configured"
+		},
+		Date: {
+			description: "configured"
+		},
+		Error: {
+			description: "configured"
+		},
+		Function: {
+			description: "configured"
+		},
+		Map: {
+			description: "configured"
+		},
+		Promise: {
+			description: "configured"
+		},
+		RegExp: {
+			description: "configured"
+		},
+		Set: {
+			description: "configured"
+		},
+		WeakMap: {
+			description: "configured"
+		},
+		WeakSet: {
+			description: "configured"
+		},
+		ArrayBuffer: {
+			description: "configured"
+		},
+		Blob: {
+			description: "configured"
+		},
+		File: {
+			description: "configured"
+		},
+		Headers: {
+			description: "configured"
+		},
+		Request: {
+			description: "configured"
+		},
+		Response: {
+			description: "configured"
+		},
+		URL: {
+			description: "configured"
+		},
+		Key: {
+			description: "configured"
+		},
+		"number.integer": {
+			description: "configured"
+		},
+		"number.epoch": {
+			description: "configured"
+		},
+		"number.finite": {
+			description: "configured"
+		},
+		"number.safe": {
+			description: "configured"
+		},
+		"number.NaN": {
+			description: "configured"
+		},
+		"number.Infinity": {
+			description: "configured"
+		},
+		"number.NegativeInfinity": {
+			description: "configured"
+		},
+		"object.json.stringify": {
+			description: "configured"
+		},
+		"string.alpha": {
+			description: "configured"
+		},
+		"string.alphanumeric": {
+			description: "configured"
+		},
+		"string.hex": {
+			description: "configured"
+		},
+		"string.base64.url": {
+			description: "configured"
+		},
+		"string.capitalize.preformatted": {
+			description: "configured"
+		},
+		"string.creditCard": {
+			description: "configured"
+		},
+		"string.date.parse": {
+			description: "configured"
+		},
+		"string.date.iso.parse": {
+			description: "configured"
+		},
+		"string.date.epoch.parse": {
+			description: "configured"
+		},
+		"string.digits": {
+			description: "configured"
+		},
+		"string.email": {
+			description: "configured"
+		},
+		"string.integer.parse": {
+			description: "configured"
+		},
+		"string.ip.v4": {
+			description: "configured"
+		},
+		"string.ip.v6": {
+			description: "configured"
+		},
+		"string.json.parse": {
+			description: "configured"
+		},
+		"string.lower.preformatted": {
+			description: "configured"
+		},
+		"string.normalize.NFC.preformatted": {
+			description: "configured"
+		},
+		"string.normalize.NFD.preformatted": {
+			description: "configured"
+		},
+		"string.normalize.NFKC.preformatted": {
+			description: "configured"
+		},
+		"string.normalize.NFKD.preformatted": {
+			description: "configured"
+		},
+		"string.numeric.parse": {
+			description: "configured"
+		},
+		"string.regex": {
+			description: "configured"
+		},
+		"string.semver": {
+			description: "configured"
+		},
+		"string.trim.preformatted": {
+			description: "configured"
+		},
+		"string.upper.preformatted": {
+			description: "configured"
+		},
+		"string.url.parse": {
+			description: "configured"
+		},
+		"string.uuid.v1": {
+			description: "configured"
+		},
+		"string.uuid.v2": {
+			description: "configured"
+		},
+		"string.uuid.v3": {
+			description: "configured"
+		},
+		"string.uuid.v4": {
+			description: "configured"
+		},
+		"string.uuid.v5": {
+			description: "configured"
+		},
+		"string.uuid.v6": {
+			description: "configured"
+		},
+		"string.uuid.v7": {
+			description: "configured"
+		},
+		"string.uuid.v8": {
+			description: "configured"
+		},
+		"unknown.any": {
+			description: "configured"
+		},
+		"Array.readonly": {
+			description: "configured"
+		},
+		"Array.index": {
+			description: "configured"
+		},
+		"FormData.value": {
+			description: "configured"
+		},
+		"FormData.parsed": {
+			description: "configured"
+		},
+		"FormData.parse": {
+			description: "configured"
+		},
+		"TypedArray.Int8": {
+			description: "configured"
+		},
+		"TypedArray.Uint8": {
+			description: "configured"
+		},
+		"TypedArray.Uint8Clamped": {
+			description: "configured"
+		},
+		"TypedArray.Int16": {
+			description: "configured"
+		},
+		"TypedArray.Uint16": {
+			description: "configured"
+		},
+		"TypedArray.Int32": {
+			description: "configured"
+		},
+		"TypedArray.Uint32": {
+			description: "configured"
+		},
+		"TypedArray.Float32": {
+			description: "configured"
+		},
+		"TypedArray.Float64": {
+			description: "configured"
+		},
+		"TypedArray.BigInt64": {
+			description: "configured"
+		},
+		"TypedArray.BigUint64": {
+			description: "configured"
+		}
+	}
 })

--- a/ark/type/__tests__/keywords/number.test.ts
+++ b/ark/type/__tests__/keywords/number.test.ts
@@ -65,9 +65,7 @@ contextualize(() => {
 		attest(Finite(-Infinity).toString()).snap(
 			"must be a finite number (was -Infinity)"
 		)
-		attest(Finite(NaN).toString()).snap(
-			"must be a number (was NaN)"
-		)
+		attest(Finite(NaN).toString()).snap("must be a number (was NaN)")
 	})
 
 	it("doesn't allow NaN by default", () => {

--- a/ark/type/__tests__/keywords/number.test.ts
+++ b/ark/type/__tests__/keywords/number.test.ts
@@ -54,6 +54,22 @@ contextualize(() => {
 		attest(Safe(NaN).toString()).snap("must be a number (was NaN)")
 	})
 
+	it("finite", () => {
+		const Finite = type("number.finite")
+		attest(Finite(42)).snap(42)
+		attest(Finite(-3.14)).snap(-3.14)
+		attest(Finite(0)).snap(0)
+		attest(Finite(Infinity).toString()).snap(
+			"must be a finite number (was Infinity)"
+		)
+		attest(Finite(-Infinity).toString()).snap(
+			"must be a finite number (was -Infinity)"
+		)
+		attest(Finite(NaN).toString()).snap(
+			"must be a number (was NaN)"
+		)
+	})
+
 	it("doesn't allow NaN by default", () => {
 		attest(type.number.allows(Number.NaN)).equals(false)
 		attest(type.number(Number.NaN).toString()).snap(

--- a/ark/type/__tests__/keywords/number.test.ts
+++ b/ark/type/__tests__/keywords/number.test.ts
@@ -59,6 +59,8 @@ contextualize(() => {
 		attest(Finite(42)).snap(42)
 		attest(Finite(-3.14)).snap(-3.14)
 		attest(Finite(0)).snap(0)
+		attest(Finite.allows(Number.MAX_VALUE)).equals(true)
+		attest(Finite.allows(-Number.MAX_VALUE)).equals(true)
 		attest(Finite(Infinity).toString()).snap(
 			"must be a finite number (was Infinity)"
 		)

--- a/ark/type/keywords/number.ts
+++ b/ark/type/keywords/number.ts
@@ -34,11 +34,23 @@ export const integer = rootSchema({
 	divisor: 1
 })
 
+const finite = rootSchema({
+	domain: {
+		domain: "number",
+		numberAllowsNaN: false
+	},
+	predicate: {
+		meta: "a finite number",
+		predicate: (n: number) => Number.isFinite(n)
+	}
+})
+
 export const number: number.module = Scope.module(
 	{
 		root: intrinsic.number,
 		integer,
 		epoch,
+		finite,
 		safe: rootSchema({
 			domain: {
 				domain: "number",
@@ -64,6 +76,7 @@ export declare namespace number {
 	export type $ = {
 		root: number
 		epoch: number
+		finite: number
 		integer: number
 		safe: number
 		NaN: number

--- a/ark/type/keywords/number.ts
+++ b/ark/type/keywords/number.ts
@@ -39,9 +39,13 @@ const finite = rootSchema({
 		domain: "number",
 		numberAllowsNaN: false
 	},
-	predicate: {
-		meta: "a finite number",
-		predicate: (n: number) => Number.isFinite(n)
+	min: {
+		rule: -Number.MAX_VALUE,
+		meta: "a finite number"
+	},
+	max: {
+		rule: Number.MAX_VALUE,
+		meta: "a finite number"
 	}
 })
 


### PR DESCRIPTION
## Summary

Closes #1598

Adds `number.finite` keyword that rejects `NaN`, `Infinity`, and `-Infinity`. Matches `Number.isFinite()` semantics.

**Implementation** follows the `number.safe` pattern exactly:
- `numberAllowsNaN: false` on the domain node (rejects NaN)
- `min`/`max` bounds at `±Number.MAX_VALUE` with custom `meta: "a finite number"` (rejects ±Infinity with a clear error message)

Using `min`/`max` rather than a predicate ensures the constraint is composable (intersects with user bounds), JIT-compiled, introspectable, and compatible with the fast-check arbitrary generator.

**Error messages:**
- `Infinity` → `"must be a finite number (was Infinity)"`
- `-Infinity` → `"must be a finite number (was -Infinity)"`
- `NaN` → `"must be a number (was NaN)"` (domain-level rejection)

## Test plan

- [x] Finite numbers accepted (integers, floats, zero, ±MAX_VALUE boundary)
- [x] ±Infinity rejected with descriptive error
- [x] NaN rejected at domain level
- [x] `pnpm prChecks` passes (format, lint, typecheck, full test suite)