### PR TITLE
docs: add Cursor rules, syntax cheat sheet, and AI agent context

### DIFF
--- a/.cursor/rules/arktype.mdc
+++ b/.cursor/rules/arktype.mdc
@@ -82,7 +82,7 @@ type("string").or("number")
 Keywords follow `typescriptType.constraint.subconstraint`:
 
 - `string.email`, `string.uuid`, `string.url`
-- `number.integer`, `number.finite`, `number.safe`
+- `number.integer`, `number.safe`, `number.epoch`
 - `string.trim`, `string.json.parse`, `string.date.parse` (morphs)
 
 ## Operators

--- a/.cursor/rules/arktype.mdc
+++ b/.cursor/rules/arktype.mdc
@@ -1,6 +1,6 @@
 ---
 description: When working with ArkType for schema validation. Covers common patterns, pitfalls, and idiomatic usage.
-globs:
+globs: "**/*.ts"
 alwaysApply: false
 ---
 
@@ -93,7 +93,7 @@ type("string & /@pattern/")   // intersection
 type("number > 0")            // exclusive min
 type("number >= 0")           // inclusive min
 type("string <= 255")         // max length
-type("string = 'default'")    // default value
+type({ name: "string = 'default'" })  // default value
 ```
 
 ## Morphs

--- a/.cursor/rules/arktype.mdc
+++ b/.cursor/rules/arktype.mdc
@@ -1,0 +1,113 @@
+---
+description: When working with ArkType for schema validation. Covers common patterns, pitfalls, and idiomatic usage.
+globs:
+alwaysApply: false
+---
+
+# ArkType Usage Guidelines
+
+## Optional Keys
+
+```ts
+// ❌ WRONG
+type({ name: "string | undefined" })
+
+// ✅ CORRECT — append ? to the key
+type({ "name?": "string" })
+```
+
+## Schema References
+
+**In objects** — pass schemas directly:
+```ts
+const Inner = type({ foo: "string" })
+const Outer = type({ inner: Inner })
+```
+
+**In records** — use index signature syntax:
+```ts
+// ❌ WRONG: "Record<string, Schema>"
+// ✅ CORRECT:
+type({ "[string]": Schema })
+```
+
+**In arrays** — use `.array()`:
+```ts
+// ❌ WRONG: type([Schema]) — creates a 1-element tuple
+// ✅ CORRECT:
+Schema.array()
+```
+
+## Type Inference
+
+```ts
+type User = typeof UserSchema.infer
+```
+
+## Type Declaration
+
+Match a schema to an existing TypeScript type:
+```ts
+const Schema = type.declare<MyType>().type({
+  items: type.string.array().readonly()  // readonly string[]
+})
+```
+
+## Error Handling
+
+```ts
+const out = Schema(data)
+if (out instanceof type.errors) {
+  console.error(out.summary)
+}
+```
+
+## Syntax Kinds
+
+Three equivalent ways to define types:
+
+```ts
+// string expression
+type("string | number")
+
+// tuple expression
+type(["string", "|", "number"])
+
+// chained
+type("string").or("number")
+```
+
+## Keywords Pattern
+
+Keywords follow `typescriptType.constraint.subconstraint`:
+
+- `string.email`, `string.uuid`, `string.url`
+- `number.integer`, `number.finite`, `number.safe`
+- `string.trim`, `string.json.parse`, `string.date.parse` (morphs)
+
+## Operators
+
+```ts
+type("string | number")       // union
+type("string & /@pattern/")   // intersection
+type("number > 0")            // exclusive min
+type("number >= 0")           // inclusive min
+type("string <= 255")         // max length
+type("string = 'default'")    // default value
+```
+
+## Morphs
+
+```ts
+type("string").to("number.integer") // validated transform
+type("string").pipe(s => s.trim())  // custom transform
+type("string.json.parse")           // built-in parse morph
+```
+
+## Common Mistakes
+
+1. `type([X])` creates a tuple, not an array — use `X.array()`
+2. `"string | undefined"` for optional — use `"key?": "string"`
+3. `"Record<string, T>"` — use `type({ "[string]": T })`
+4. Re-validating after `type()` passes — trust ArkType's output
+5. `typeof Schema.t` — use `typeof Schema.infer` for output type

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,14 +24,17 @@ pnpm testTyped --skipTypes # run tests without type checking
 ## Key Patterns
 
 **String keywords** follow `typescriptType.constraint.subconstraint`:
+
 - `string.email`, `string.uuid`, `string.url`, `string.hex`
 - `number.integer`, `number.safe`, `number.epoch`
 - Morphs: `string.trim`, `string.json.parse`, `string.date.parse`
 
 **Adding a regex string validator:**
+
 ```ts
 const myValidator = regexStringNode(/^pattern$/, "description")
 ```
+
 Register in `Scope.module()` in `ark/type/keywords/string.ts` and add to the namespace `$` type.
 
 **Adding a number keyword:**
@@ -62,13 +65,13 @@ type User = typeof UserSchema.infer
 // error handling
 const out = Schema(data)
 if (out instanceof type.errors) {
-  console.error(out.summary)
+	console.error(out.summary)
 }
 
 // three syntax kinds (equivalent):
-type("string | number")            // string expression
-type(["string", "|", "number"])    // tuple expression
-type("string").or("number")        // chained
+type("string | number") // string expression
+type(["string", "|", "number"]) // tuple expression
+type("string").or("number") // chained
 ```
 
 ## Common Gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# ArkType — Agent Context
+
+ArkType is TypeScript's 1:1 validator, optimized from editor to runtime. It parses TypeScript-like string syntax at runtime — this is unique among validation libraries.
+
+## Quick Start
+
+```bash
+pnpm i && pnpm build     # install and build all packages
+pnpm prChecks             # lint + build + test (run before PRs)
+pnpm testTyped --skipTypes # run tests without type checking
+```
+
+## Monorepo Structure
+
+- `ark/type/` — main validation library (`arktype` on npm)
+- `ark/schema/` — schema layer (constraint nodes, refinements, scopes)
+- `ark/util/` — shared utilities
+- `ark/docs/` — documentation site (Fumadocs/Next.js)
+- `ark/json-schema/` — JSON Schema conversion
+- `ark/regex/` — ArkRegex type-safe regex
+- `ark/attest/` — custom assertion/test library
+- `ark/fast-check/` — property testing integration
+
+## Key Patterns
+
+**String keywords** follow `typescriptType.constraint.subconstraint`:
+- `string.email`, `string.uuid`, `string.url`, `string.hex`
+- `number.integer`, `number.safe`, `number.epoch`
+- Morphs: `string.trim`, `string.json.parse`, `string.date.parse`
+
+**Adding a regex string validator:**
+```ts
+const myValidator = regexStringNode(/^pattern$/, "description")
+```
+Register in `Scope.module()` in `ark/type/keywords/string.ts` and add to the namespace `$` type.
+
+**Adding a number keyword:**
+Use `rootSchema()` with `domain`, `min`/`max`, or `predicate` constraints. See `number.safe` in `ark/type/keywords/number.ts`.
+
+## Code Style
+
+- Tabs, no semicolons, no trailing commas (`prettier` enforced)
+- `experimentalTernaries: true` — `?` at end of line, `:` on next line
+- `arrowParens: "avoid"` — `x => x` not `(x) => x`
+- Tests use `attest` (custom lib) with `.snap()` for snapshots
+
+## ArkType Syntax Cheat Sheet
+
+```ts
+// optional keys — append ? to the key name
+type({ "name?": "string" })
+
+// arrays — use .array(), NOT type([Schema])
+Schema.array()
+
+// records — use index signature syntax
+type({ "[string]": ValueSchema })
+
+// type inference
+type User = typeof UserSchema.infer
+
+// error handling
+const out = Schema(data)
+if (out instanceof type.errors) {
+  console.error(out.summary)
+}
+
+// three syntax kinds (equivalent):
+type("string | number")            // string expression
+type(["string", "|", "number"])    // tuple expression
+type("string").or("number")        // chained
+```
+
+## Common Gotchas
+
+- `type([X])` creates a 1-element **tuple**, not an array — use `X.array()`
+- `"string | undefined"` for optional — use `"key?": "string"` instead
+- `"Record<string, T>"` doesn't work — use `type({ "[string]": T })`
+- `safeParse()` doesn't exist — call the type directly: `const out = Schema(data)`
+- `auth-schema.ts` is generated — never edit it
+- `regexStringNode()` patterns must be anchored with `^`/`$`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,5 +80,6 @@ type("string").or("number") // chained
 - `"string | undefined"` for optional — use `"key?": "string"` instead
 - `"Record<string, T>"` doesn't work — use `type({ "[string]": T })`
 - `safeParse()` doesn't exist — call the type directly: `const out = Schema(data)`
-- `auth-schema.ts` is generated — never edit it
 - `regexStringNode()` patterns must be anchored with `^`/`$`
+
+<!-- Keep in sync: .cursor/rules/arktype.mdc, ark/docs/content/docs/cheat-sheet.mdx -->

--- a/ark/docs/content/docs/cheat-sheet.mdx
+++ b/ark/docs/content/docs/cheat-sheet.mdx
@@ -49,8 +49,8 @@ type("number > 0")         // exclusive min
 type("number >= 0")        // inclusive min
 type("string <= 255")      // max length
 
-// defaults — only valid inside objects/tuples
-type({ "email?": "string.email = 'n/a'" })
+// defaults — valid inside objects (key becomes implicitly optional)
+type({ email: "string.email = 'n/a'" })
 ```
 
 ## Objects
@@ -58,8 +58,8 @@ type({ "email?": "string.email = 'n/a'" })
 ```ts
 const User = type({
 	name: "string",
-	"email?": "string.email",    // optional key — use '?' suffix in the key
-	"age?": "number >= 0 = 0"    // optional with default
+	"email?": "string.email",  // optional key — use '?' suffix in the key
+	age: "number >= 0 = 0"     // default value — implicitly optional
 })
 
 // index signatures (Record types)

--- a/ark/docs/content/docs/cheat-sheet.mdx
+++ b/ark/docs/content/docs/cheat-sheet.mdx
@@ -27,27 +27,27 @@ Keywords follow a `typescriptType.constraint.subconstraint` pattern:
 
 ```ts
 // string keywords
-type("string.email")       // email format
-type("string.uuid")        // UUID format
-type("string.url")         // parsable URL
-type("string.trim")        // morph: trims whitespace
-type("string.json.parse")  // morph: string → parsed JSON
-type("string.date.parse")  // morph: string → Date
+type("string.email") // email format
+type("string.uuid") // UUID format
+type("string.url") // parsable URL
+type("string.trim") // morph: trims whitespace
+type("string.json.parse") // morph: string → parsed JSON
+type("string.date.parse") // morph: string → Date
 
 // number keywords
-type("number.integer")     // whole numbers
-type("number.safe")        // within safe integer range
-type("number.epoch")       // valid Unix timestamp
+type("number.integer") // whole numbers
+type("number.safe") // within safe integer range
+type("number.epoch") // valid Unix timestamp
 ```
 
 ## Operators
 
 ```ts
-type("string | number")    // union
-type("string & /@foo/")    // intersection
-type("number > 0")         // exclusive min
-type("number >= 0")        // inclusive min
-type("string <= 255")      // max length
+type("string | number") // union
+type("string & /@foo/") // intersection
+type("number > 0") // exclusive min
+type("number >= 0") // inclusive min
+type("string <= 255") // max length
 
 // defaults — valid inside objects (key becomes implicitly optional)
 type({ email: "string.email = 'n/a'" })
@@ -58,13 +58,13 @@ type({ email: "string.email = 'n/a'" })
 ```ts
 const User = type({
 	name: "string",
-	"email?": "string.email",  // optional key — use '?' suffix in the key
-	age: "number >= 0 = 0"     // default value — implicitly optional
+	"email?": "string.email", // optional key — use '?' suffix in the key
+	age: "number >= 0 = 0" // default value — implicitly optional
 })
 
 // index signatures (Record types)
 const Env = type({
-	"[string]": "string"         // Record<string, string>
+	"[string]": "string" // Record<string, string>
 })
 
 // strip undeclared keys
@@ -74,7 +74,7 @@ const Strict = User.onUndeclaredKey("delete")
 ## Arrays and Tuples
 
 ```ts
-const Strings = type("string[]")    // string expression
+const Strings = type("string[]") // string expression
 const Numbers = type.number.array() // chained
 
 // tuples — fixed length and positional types
@@ -82,8 +82,8 @@ const Pair = type(["string", "number"])
 
 // GOTCHA: type([X]) is a 1-element tuple, NOT an array
 const Item = type({ id: "string" })
-const Wrong = type([Item])       // tuple of exactly [Item]
-const Right = Item.array()       // Item[]
+const Wrong = type([Item]) // tuple of exactly [Item]
+const Right = Item.array() // Item[]
 
 // readonly
 const Ids = type("string[]").readonly() // readonly string[]
@@ -118,9 +118,9 @@ const ParsedInt = type("string").to("number.integer")
 const ToUpper = type("string").pipe(s => s.toUpperCase())
 
 // built-in parse morphs
-const ParseDate = type("string.date.parse")     // string → Date
-const ParseJson = type("string.json.parse")      // string → object
-const Trimmed = type("string.trim")              // string → trimmed string
+const ParseDate = type("string.date.parse") // string → Date
+const ParseJson = type("string.json.parse") // string → object
+const Trimmed = type("string.trim") // string → trimmed string
 ```
 
 ## Type Inference
@@ -157,10 +157,10 @@ if (out instanceof type.errors) {
 
 ## Common Gotchas
 
-| Mistake | Fix |
-|---------|-----|
-| `name: "string \| undefined"` for optional | Use `"name?": "string"` — append `?` to the **key** |
-| `type([Schema])` for arrays | Use `Schema.array()` — brackets create tuples |
-| `"Record<string, T>"` for records | Use `type({ "[string]": T })` — index signature syntax |
-| Manually re-validating after `type()` | Trust ArkType's output — it already validated the structure |
-| `type User = typeof Schema.t` | Use `typeof Schema.infer` for the output type |
+| Mistake                                    | Fix                                                         |
+| ------------------------------------------ | ----------------------------------------------------------- |
+| `name: "string \| undefined"` for optional | Use `"name?": "string"` — append `?` to the **key**         |
+| `type([Schema])` for arrays                | Use `Schema.array()` — brackets create tuples               |
+| `"Record<string, T>"` for records          | Use `type({ "[string]": T })` — index signature syntax      |
+| Manually re-validating after `type()`      | Trust ArkType's output — it already validated the structure |
+| `type User = typeof Schema.t`              | Use `typeof Schema.infer` for the output type               |

--- a/ark/docs/content/docs/cheat-sheet.mdx
+++ b/ark/docs/content/docs/cheat-sheet.mdx
@@ -1,0 +1,159 @@
+---
+title: Cheat Sheet
+---
+
+A quick reference for ArkType's most common patterns. For full docs, explore the sidebar.
+
+## Syntax Kinds
+
+ArkType offers three ways to define the same type. Use whichever fits your context.
+
+```ts
+import { type } from "arktype"
+
+// string expression — most concise
+const StringSyntax = type("string | number")
+
+// tuple expression — embed non-string operands
+const TupleSyntax = type(["string", "|", "number"])
+
+// chained — compose existing types
+const Chained = type("string").or("number")
+```
+
+## Keywords
+
+Keywords follow a `typescriptType.constraint.subconstraint` pattern:
+
+```ts
+// string keywords
+type("string.email")       // email format
+type("string.uuid")        // UUID format
+type("string.url")         // parsable URL
+type("string.trim")        // morph: trims whitespace
+type("string.json.parse")  // morph: string → parsed JSON
+type("string.date.parse")  // morph: string → Date
+
+// number keywords
+type("number.integer")     // whole numbers
+type("number.finite")      // no Infinity or NaN
+type("number.safe")        // within safe integer range
+type("number.epoch")       // valid Unix timestamp
+```
+
+## Operators
+
+```ts
+type("string | number")      // union
+type("string & /@foo/")      // intersection
+type("number > 0")           // exclusive min
+type("number >= 0")          // inclusive min
+type("string <= 255")        // max length
+type("string.email = 'n/a'") // default value
+```
+
+## Objects
+
+```ts
+const User = type({
+	name: "string",
+	"email?": "string.email",    // optional key — use '?' suffix in the key
+	"age?": "number >= 0 = 0"    // optional with default
+})
+
+// index signatures (Record types)
+const Env = type({
+	"[string]": "string"         // Record<string, string>
+})
+
+// strip undeclared keys
+const Strict = User.onUndeclaredKey("delete")
+```
+
+## Arrays and Tuples
+
+```ts
+const Strings = type("string[]")    // string expression
+const Numbers = type.number.array() // chained
+
+// tuples — fixed length and positional types
+const Pair = type(["string", "number"])
+
+// GOTCHA: type([MyType]) is a 1-element tuple, NOT an array
+const Wrong = type([MyType])       // tuple of exactly [MyType]
+const Right = MyType.array()       // MyType[]
+
+// readonly
+const Ids = type("string[]").readonly() // readonly string[]
+```
+
+## Composition
+
+```ts
+const Device = type({
+	platform: "'android' | 'ios'",
+	"version?": "string"
+})
+
+// reference in another type — just pass it directly
+const User = type({
+	name: "string",
+	device: Device
+})
+
+// fluent composition
+const Admin = User.and({ role: "'admin'" })
+const Guest = type({ name: "string" }).or({ token: "string" })
+```
+
+## Morphs and Pipes
+
+```ts
+// .to() — validated input → validated output
+const ParsedInt = type("string").to("number.integer")
+
+// .pipe() — validated input → transform function
+const ToUpper = type("string").pipe(s => s.toUpperCase())
+
+// built-in parse morphs
+const ParseDate = type("string.date.parse")     // string → Date
+const ParseJson = type("string.json.parse")      // string → object
+const Trimmed = type("string.trim")              // string → trimmed string
+```
+
+## Type Inference
+
+```ts
+const User = type({
+	name: "string",
+	"age?": "number"
+})
+
+// extract the TypeScript type
+type User = typeof User.infer
+// { name: string; age?: number }
+```
+
+## Error Handling
+
+```ts
+const out = User(unknownData)
+
+if (out instanceof type.errors) {
+	// ArkErrors — array-like with .summary
+	console.error(out.summary)
+} else {
+	// out is typed as User
+	console.log(out.name)
+}
+```
+
+## Common Gotchas
+
+| Mistake | Fix |
+|---------|-----|
+| `name: "string \| undefined"` for optional | Use `"name?": "string"` — append `?` to the **key** |
+| `type([Schema])` for arrays | Use `Schema.array()` — brackets create tuples |
+| `"Record<string, T>"` for records | Use `type({ "[string]": T })` — index signature syntax |
+| Manually re-validating after `type()` | Trust ArkType's output — it already validated the structure |
+| `type User = typeof Schema.t` | Use `typeof Schema.infer` for the output type |

--- a/ark/docs/content/docs/cheat-sheet.mdx
+++ b/ark/docs/content/docs/cheat-sheet.mdx
@@ -139,13 +139,18 @@ type User = typeof User.infer
 ## Error Handling
 
 ```ts
-const out = User(unknownData)
+const User = type({
+	name: "string",
+	"age?": "number"
+})
+
+const out = User({ name: "Alan", age: "not a number" })
 
 if (out instanceof type.errors) {
 	// ArkErrors — array-like with .summary
 	console.error(out.summary)
 } else {
-	// out is typed as User
+	// out is typed as { name: string; age?: number }
 	console.log(out.name)
 }
 ```

--- a/ark/docs/content/docs/cheat-sheet.mdx
+++ b/ark/docs/content/docs/cheat-sheet.mdx
@@ -43,12 +43,14 @@ type("number.epoch")       // valid Unix timestamp
 ## Operators
 
 ```ts
-type("string | number")      // union
-type("string & /@foo/")      // intersection
-type("number > 0")           // exclusive min
-type("number >= 0")          // inclusive min
-type("string <= 255")        // max length
-type("string.email = 'n/a'") // default value
+type("string | number")    // union
+type("string & /@foo/")    // intersection
+type("number > 0")         // exclusive min
+type("number >= 0")        // inclusive min
+type("string <= 255")      // max length
+
+// defaults — only valid inside objects/tuples
+type({ "email?": "string.email = 'n/a'" })
 ```
 
 ## Objects

--- a/ark/docs/content/docs/cheat-sheet.mdx
+++ b/ark/docs/content/docs/cheat-sheet.mdx
@@ -80,9 +80,10 @@ const Numbers = type.number.array() // chained
 // tuples — fixed length and positional types
 const Pair = type(["string", "number"])
 
-// GOTCHA: type([MyType]) is a 1-element tuple, NOT an array
-const Wrong = type([MyType])       // tuple of exactly [MyType]
-const Right = MyType.array()       // MyType[]
+// GOTCHA: type([X]) is a 1-element tuple, NOT an array
+const Item = type({ id: "string" })
+const Wrong = type([Item])       // tuple of exactly [Item]
+const Right = Item.array()       // Item[]
 
 // readonly
 const Ids = type("string[]").readonly() // readonly string[]

--- a/ark/docs/content/docs/cheat-sheet.mdx
+++ b/ark/docs/content/docs/cheat-sheet.mdx
@@ -36,7 +36,6 @@ type("string.date.parse")  // morph: string → Date
 
 // number keywords
 type("number.integer")     // whole numbers
-type("number.finite")      // no Infinity or NaN
 type("number.safe")        // within safe integer range
 type("number.epoch")       // valid Unix timestamp
 ```

--- a/ark/docs/content/docs/meta.json
+++ b/ark/docs/content/docs/meta.json
@@ -1,6 +1,7 @@
 {
 	"pages": [
 		"intro",
+		"cheat-sheet",
 		"primitives",
 		"objects",
 		"keywords",


### PR DESCRIPTION
## Summary

Closes #1539, closes #1562

Adds three resources to improve AI/LLM integration with ArkType:

1. **`.cursor/rules/arktype.mdc`** — Cursor rules file with common ArkType patterns and
   pitfalls, adapted from the battle-tested cheat sheet in #1539. Activates when working
   with ArkType code in Cursor.

2. **`ark/docs/content/docs/cheat-sheet.mdx`** — Syntax cheat sheet covering operators,
   keywords mental model, syntax kinds, and common gotchas. Per maintainer request in #1562:
   "markdown page with code and comments." Automatically included in `llms.txt` via the
   existing `writeLlmsTxt()` build step.

3. **`CLAUDE.md` + `AGENTS.md` (symlinked)** — AI agent context file covering monorepo
   structure, code style, key patterns, and common gotchas. Read by Claude Code, Codex,
   and other agent systems.

The cheat sheet is placed after Intro in sidebar navigation — the natural place a new user
looks after the getting-started tutorial.

Follow-up items from #1539 (llms.txt optimization, node_modules packaging) tracked separately.

## Test plan

- [x] `pnpm buildDocs` succeeds — all MDX code blocks compile cleanly
- [x] Cheat sheet appears in sidebar navigation after Intro
- [x] Cheat sheet content included in `llms.txt`
- [x] `pnpm checkPrettier` passes
- [x] `pnpm checkEslint` passes
- [x] Full test suite passes (1703 tests)