### PR TITLE
fix `this[]` shallow resolution cycle in self-referential types

### DIFF
--- a/ark/schema/__tests__/alias.test.ts
+++ b/ark/schema/__tests__/alias.test.ts
@@ -1,0 +1,62 @@
+import { attest, contextualize } from "@ark/attest"
+import {
+	arkKind,
+	nodesByRegisteredId,
+	schemaScope,
+	type NodeId
+} from "@ark/schema"
+import { writeShallowCycleErrorMessage } from "@ark/schema/internal/roots/alias.ts"
+
+contextualize(() => {
+	it("alias resolution detects self-cycling context", () => {
+		// Synthesize a context node registered to its own id, the shape an
+		// in-progress parse would have before the enclosing finalize swaps
+		// the resolved root in. Since BaseScope.finalize now defers in this
+		// case (see scope.ts hasUnresolvedContextAlias), this is the only
+		// way to exercise the cycle detector through a test.
+		const cyclicId = "shallowCycleProbeSelf" as NodeId
+		nodesByRegisteredId[cyclicId] = {
+			[arkKind]: "context",
+			id: cyclicId
+		} as never
+		try {
+			const alias = schemaScope({}).node(
+				"alias",
+				{ reference: cyclicId },
+				{ prereduced: true }
+			)
+			attest(() => alias.resolution).throws(
+				writeShallowCycleErrorMessage(cyclicId, [cyclicId])
+			)
+		} finally {
+			delete nodesByRegisteredId[cyclicId]
+		}
+	})
+
+	it("alias resolution detects multi-step context cycle", () => {
+		// A -> B -> A should also trip the detector after walking once.
+		const aId = "shallowCycleProbeA" as NodeId
+		const bId = "shallowCycleProbeB" as NodeId
+		nodesByRegisteredId[aId] = {
+			[arkKind]: "context",
+			id: bId
+		} as never
+		nodesByRegisteredId[bId] = {
+			[arkKind]: "context",
+			id: aId
+		} as never
+		try {
+			const alias = schemaScope({}).node(
+				"alias",
+				{ reference: aId },
+				{ prereduced: true }
+			)
+			attest(() => alias.resolution).throws(
+				writeShallowCycleErrorMessage(bId, [bId, aId])
+			)
+		} finally {
+			delete nodesByRegisteredId[aId]
+			delete nodesByRegisteredId[bId]
+		}
+	})
+})

--- a/ark/schema/scope.ts
+++ b/ark/schema/scope.ts
@@ -709,6 +709,14 @@ export abstract class BaseScope<$ extends {} = {}> {
 	}
 
 	finalize<node extends BaseRoot>(node: node): node {
+		// If this node contains an alias whose reference still points to an
+		// in-progress context node (e.g. `this[]` parsed before its enclosing
+		// type has finished), defer finalization. The enclosing parse will
+		// finalize once the context has been replaced with the resolved node.
+		// Gating on isCyclic skips the reference walk for non-cyclic roots,
+		// which are the overwhelming majority of finalize calls.
+		if (node.isCyclic && hasUnresolvedContextAlias(node)) return node
+
 		bootstrapAliasReferences(node)
 		if (!node.precompilation && !this.resolvedConfig.jitless)
 			precompile(node.references)
@@ -750,6 +758,19 @@ export class SchemaScope<$ extends {} = {}> extends BaseScope<$> {
 		return v
 	}
 }
+
+// Invariant: scope-named aliases are normalized to `$name` references (see
+// alias.ts `serialize` and the `$`-prefix branch in `_resolve`), while
+// synthetic `this` aliases use a bare context NodeId (see unenclosed.ts
+// `maybeParseReference`). The `$`-prefix carve-out skips scope aliases so
+// only synthetic `this` references can defer finalization here.
+const hasUnresolvedContextAlias = (node: BaseRoot): boolean =>
+	node.references.some(
+		ref =>
+			ref.hasKind("alias") &&
+			ref.reference[0] !== "$" &&
+			hasArkKind(nodesByRegisteredId[ref.reference as NodeId], "context")
+	)
 
 const bootstrapAliasReferences = (resolution: BaseRoot | GenericRoot) => {
 	const aliases = resolution.references.filter(node => node.hasKind("alias"))

--- a/ark/type/__tests__/this.test.ts
+++ b/ark/type/__tests__/this.test.ts
@@ -109,4 +109,42 @@ contextualize(() => {
 			"a must be a string (was missing), b.a must be a string (was missing) or b.b must be b.b.a must be a string (was missing) or b.b.b must be an object (was missing) (was {})"
 		)
 	})
+
+	// https://github.com/arktypeio/arktype/issues/1406
+	it("this[] (array of self)", () => {
+		const T = type({
+			name: "string",
+			"children?": "this[]"
+		})
+
+		attest(T).type.toString.snap(
+			"Type<{ name: string; children?: cyclic[] }, {}>"
+		)
+
+		attest(T({ name: "a" })).snap({ name: "a" })
+		attest(T({ name: "a", children: [{ name: "b" }] })).snap({
+			name: "a",
+			children: [{ name: "b" }]
+		})
+		attest(T({ name: "a", children: [{ name: 5 as never }] }).toString()).snap(
+			"children[0].name must be a string (was a number)"
+		)
+	})
+
+	it("this[] in unions of self", () => {
+		const T = type({
+			"AND?": "this[]",
+			"OR?": "this[]",
+			"name?": "string"
+		})
+
+		attest(T).type.toString.snap(`Type<
+	{ AND?: cyclic[]; OR?: cyclic[]; name?: string },
+	{}
+>`)
+
+		attest(T({ AND: [{ name: "a" }, { OR: [{ name: "b" }] }] })).snap({
+			AND: [{ name: "a" }, { OR: [{ name: "b" }] }]
+		})
+	})
 })


### PR DESCRIPTION
# Fix shallow resolution cycle on `this[]` self-references

Resolves #1406.

## A note on AI assistance

I drafted this fix with AI assistance. The diagnosis, the patch, the regression tests, and this description all went through that loop. I have reviewed every change manually to the best of my ability, I made sure to reproduce the bug first with a test and then with the help of AI fix it after, traced the cycle through the alias / context-id machinery, and confirmed the fix in our own codebase. I am happy to make any changes necessary.

## What this fixes

When a schema's only self-reference is `'this[]'` (an array of the enclosing type), ArkType throws at parse time:

```
ParseError: Alias 'type84' has a shallow resolution cycle: type84->type84
```

Scalar `'this'` works. Only the array form trips the cycle detector. A minimal repro:

```ts
import { type } from "arktype"

const WhereInput = type({
	"AND?": "this[]",
	"OR?": "this[]",
	"NOT?": "this",
	name: "string"
})
//  ParseError: Alias 'type<N>' has a shallow resolution cycle
```

Both `'AND?'` and `'OR?'` produce the same `this[]` reference. During finalization, the alias resolution walks the references for the node and sees one that still points at the in-progress context node (the enclosing type hasn't been swapped in yet), and bails with the shallow-cycle error. There's no real cycle, just a finalization-order problem.

## Why this matters (our use case)

At [Trellis](https://www.trellis.org), we run a large Nx monorepo with ~1,200 libraries and a GraphQL surface generated from Prisma models. We're in the middle of migrating that surface from class-validator + `@nestjs/graphql` decorators over to ArkType-backed schemas via a custom codemod.

A huge chunk of the schema is Prisma-style `WhereInput` shapes that look exactly like the repro above: `AND`, `OR`, `NOT` fields that reference the enclosing input type as both a single value and an array.

We considered rewriting the codemod to emit `scope({...}).export()` for every recursive type just to dodge this codepath, which would have meant hoisting every `.describe(...)`'d field into a const (scope literals don't accept inline `Type` siblings). Although, I am not sure that would have actually worked since I only started working with ArkType last week (when deciding to move from `class-validator` to ArkType after running some [benchmarks](https://github.com/trellisorg/graphql-class-validator-to-arktype/blob/main/RESULTS.md).

## The fix

The cycle detector is correct that we shouldn't finalize a node whose references still point to an in-progress context node, but the right response in that case is to defer finalization instead of throwing. The enclosing parse already has a finalization step that runs once the context has been replaced with the resolved node. This PR lets that finalize complete the work that was deferred.

In `ark/schema/scope.ts`, before running `bootstrapAliasReferences` / precompile on a node, check whether any of its references is an alias whose target is still a `context` node. If so, return early and let the enclosing parse finalize.

The `ref.reference[0] !== '$'` guard skips user-named aliases (those route through scope resolution), so this only affects the synthetic context aliases that `this` / `this[]` produce. Real shallow cycles (e.g. `scope({ a: "b", b: "a" })`) still throw, because they go through the `$name` path that this guard deliberately leaves alone.

## Verifying the fix

- Added regression tests in `ark/type/__tests__/this.test.ts` covering the `'this[]'` shape from the repro and the `AND`/`OR` union-of-self pattern.
- All existing `this.test.ts` cases still pass.
- Full `pnpm prChecks` matrix is green locally: lint, typecheck, mocha, V8 fast-property check, integration tests, attest tests, build, docs build, all benches (cyclic deltas of +0.00 to +0.16 percent, please let me know if this is acceptable), and the TS version matrix (5.1.6 / 5.9.3 / 5.9.0-dev).
- We patched the compiled output from this PR into our monorepo via `pnpm patch` and re-ran the migration. Every previously broken recursive `WhereInput` now parses, validates, and round-trips. The shallow-cycle error is gone across the board. The downstream issues we still see are unrelated (our own factory glue), not ArkType.

## Performance Considerations

Since I know performance is incredibly important (especially in this library), I tested the performance of the ordering of conditionals in the function that was added

### Microbench results: ordering of conditionals in `hasUnresolvedContextAlias`
  
  5M iterations × 5 trials per cell, median ns/call. Run 3 of 3 (consistent across all runs):

  | variant              | standard (no aliases) | cyclic in-progress (`this[]`) | resolved cyclic | scope `$`-alias only |
  |----------------------|----------------------:|------------------------------:|----------------:|---------------------:|
  | **V1 ABC** (current) | **51.66**             | **33.88**                     | **36.12**       | **22.36**            |
  | V2 ACB               | 59.09                 | 38.54                         | 38.80           | 30.98                |
  | V3 BAC               | 73.39                 | 47.40                         | 50.77           | 26.89                |
  | V4 BCA               | 112.23                | 60.12                         | 62.07           | 34.66                |
  | V5 CAB               | 94.35                 | 50.17                         | 49.38           | 35.96                |
  | V6 CBA               | 95.60                 | 51.31                         | 49.29           | 35.50                |

  **V1 ABC (the current ordering) is fastest in every scenario, including the standard case by a meaningful margin** (~13% over V2, ~40% over V3, ~120% over V4).

---

- [x] Code is up-to-date with the `main` branch
- [x] You've successfully run `pnpm prChecks` locally
- [x] There are new or updated unit tests validating the change
