### PR TITLE
fix(schema): avoid JSON.stringify crashes on ArkErrors issues slots

### DIFF
--- a/ark/schema/__tests__/errors.test.ts
+++ b/ark/schema/__tests__/errors.test.ts
@@ -207,7 +207,7 @@ contextualize(() => {
 		const result = nEvenAtLeast2["~standard"].validate({ n: 1 })
 		if (!("issues" in result)) throw new Error("expected validation failure")
 
-		const messages = result.issues.map(issue => issue.message)
+		const messages = result.issues?.map(issue => issue.message)
 		attest(messages).equals(errors.issues.map(issue => issue.message))
 		attest(messages instanceof ArkErrors).equals(false)
 
@@ -216,7 +216,7 @@ contextualize(() => {
 		) as { issues: unknown[]; messages: string[] }
 
 		attest(parsed.issues).equals(JSON.parse(JSON.stringify(errors)))
-		attest(parsed.messages).equals(messages)
+		attest(parsed.messages).equals(messages!)
 	})
 
 	it("flatByPath", () => {

--- a/ark/schema/__tests__/errors.test.ts
+++ b/ark/schema/__tests__/errors.test.ts
@@ -1,7 +1,7 @@
 import { attest, contextualize } from "@ark/attest"
 import {
 	$ark,
-	type ArkErrors,
+	ArkErrors,
 	configureSchema,
 	rootSchema,
 	schemaScope
@@ -148,6 +148,20 @@ contextualize(() => {
 	})
 
 	const errors = nEvenAtLeast2({ n: 1 }) as ArkErrors
+
+	it("Array methods allocate plain Array (Symbol.species), not ArkErrors", () => {
+		const messages = errors.issues.map(e => e.message)
+		attest(messages instanceof Array).equals(true)
+		attest(messages.constructor).equals(Array)
+		attest(messages instanceof ArkErrors).equals(false)
+
+		const mapped = errors.map(() => 1)
+		attest(mapped.constructor).equals(Array)
+		attest(mapped instanceof ArkErrors).equals(false)
+
+		attest(errors.filter(() => true).constructor).equals(Array)
+		attest(errors.slice().constructor).equals(Array)
+	})
 
 	it("serialization", () => {
 		attest(errors.toJSON()).snap([

--- a/ark/schema/__tests__/errors.test.ts
+++ b/ark/schema/__tests__/errors.test.ts
@@ -204,11 +204,9 @@ contextualize(() => {
 	})
 
 	it("serialization tolerates indexed entries without toJSON (e.g. HTTP JSON.stringify)", () => {
-		// Contract regression: ArkErrors is an Array subclass and Standard Schema
-		// FailureResult.issues is ReadonlyArray<Issue> (plain { message, path? }).
-		// We do not expose a public API that appends non-ArkError rows; the cast
-		// simulates userland / integration slots so JSON.stringify never assumes
-		// e.toJSON exists on every index (regression for TypeError on missing toJSON).
+		// Simulate an extra `issues` row shaped like Standard Schema `Issue` (`{ message, path? }`,
+		// no `toJSON`) — Ark has no public API for that, hence the cast — so `JSON.stringify`
+		// must tolerate mixed slots instead of assuming every index is an `ArkError`.
 		const mixed = nEvenAtLeast2({ n: 1 }) as ArkErrors
 		;(mixed as unknown as { push(...items: unknown[]): number }).push({
 			message: "foreign issue",

--- a/ark/schema/__tests__/errors.test.ts
+++ b/ark/schema/__tests__/errors.test.ts
@@ -196,7 +196,7 @@ contextualize(() => {
 		// simulates userland / integration slots so JSON.stringify never assumes
 		// e.toJSON exists on every index (regression for TypeError on missing toJSON).
 		const mixed = nEvenAtLeast2({ n: 1 }) as ArkErrors
-		(mixed as unknown as { push(...items: unknown[]): number }).push({
+		;(mixed as unknown as { push(...items: unknown[]): number }).push({
 			message: "foreign issue",
 			path: ["_"]
 		})

--- a/ark/schema/__tests__/errors.test.ts
+++ b/ark/schema/__tests__/errors.test.ts
@@ -203,23 +203,20 @@ contextualize(() => {
 		])
 	})
 
-	it("serialization tolerates indexed entries without toJSON (e.g. HTTP JSON.stringify)", () => {
-		// Simulate an extra `issues` row shaped like Standard Schema `Issue` (`{ message, path? }`,
-		// no `toJSON`) — Ark has no public API for that, hence the cast — so `JSON.stringify`
-		// must tolerate mixed slots instead of assuming every index is an `ArkError`.
-		const mixed = nEvenAtLeast2({ n: 1 }) as ArkErrors
-		;(mixed as unknown as { push(...items: unknown[]): number }).push({
-			message: "foreign issue",
-			path: ["_"]
-		})
-		const parsed = JSON.parse(JSON.stringify(mixed)) as unknown[]
-		attest(parsed.length).equals(2)
-		const first = parsed[0] as Record<string, unknown>
-		attest(first.code).equals("intersection")
-		attest(first.path).equals(["n"])
-		attest(typeof first.message).equals("string")
-		attest(Array.isArray(first.errors)).equals(true)
-		attest(parsed[1]).equals({ message: "foreign issue", path: ["_"] })
+	it("JSON.stringify round-trip via Standard Schema failure (e.g. HTTP error payload)", () => {
+		const result = nEvenAtLeast2["~standard"].validate({ n: 1 })
+		if (!("issues" in result)) throw new Error("expected validation failure")
+
+		const messages = result.issues.map(issue => issue.message)
+		attest(messages).equals(errors.issues.map(issue => issue.message))
+		attest(messages instanceof ArkErrors).equals(false)
+
+		const parsed = JSON.parse(
+			JSON.stringify({ issues: result.issues, messages })
+		) as { issues: unknown[]; messages: string[] }
+
+		attest(parsed.issues).equals(JSON.parse(JSON.stringify(errors)))
+		attest(parsed.messages).equals(messages)
 	})
 
 	it("flatByPath", () => {

--- a/ark/schema/__tests__/errors.test.ts
+++ b/ark/schema/__tests__/errors.test.ts
@@ -189,6 +189,16 @@ contextualize(() => {
 		])
 	})
 
+	it("serialization tolerates indexed entries without toJSON (e.g. HTTP JSON.stringify)", () => {
+		;(errors as unknown as { push(...items: unknown[]): number }).push({
+			message: "foreign issue",
+			path: ["_"]
+		})
+		const parsed = JSON.parse(JSON.stringify(errors)) as unknown[]
+		attest(parsed.length).equals(2)
+		attest(parsed[1]).equals({ message: "foreign issue", path: ["_"] })
+	})
+
 	it("flatByPath", () => {
 		attest(errors.flatByPath).snap({
 			n: [

--- a/ark/schema/__tests__/errors.test.ts
+++ b/ark/schema/__tests__/errors.test.ts
@@ -190,12 +190,23 @@ contextualize(() => {
 	})
 
 	it("serialization tolerates indexed entries without toJSON (e.g. HTTP JSON.stringify)", () => {
-		;(errors as unknown as { push(...items: unknown[]): number }).push({
+		// Contract regression: ArkErrors is an Array subclass and Standard Schema
+		// FailureResult.issues is ReadonlyArray<Issue> (plain { message, path? }).
+		// We do not expose a public API that appends non-ArkError rows; the cast
+		// simulates userland / integration slots so JSON.stringify never assumes
+		// e.toJSON exists on every index (regression for TypeError on missing toJSON).
+		const mixed = nEvenAtLeast2({ n: 1 }) as ArkErrors
+		(mixed as unknown as { push(...items: unknown[]): number }).push({
 			message: "foreign issue",
 			path: ["_"]
 		})
-		const parsed = JSON.parse(JSON.stringify(errors)) as unknown[]
+		const parsed = JSON.parse(JSON.stringify(mixed)) as unknown[]
 		attest(parsed.length).equals(2)
+		const first = parsed[0] as Record<string, unknown>
+		attest(first.code).equals("intersection")
+		attest(first.path).equals(["n"])
+		attest(typeof first.message).equals("string")
+		attest(Array.isArray(first.errors)).equals(true)
 		attest(parsed[1]).equals({ message: "foreign issue", path: ["_"] })
 	})
 

--- a/ark/schema/shared/errors.ts
+++ b/ark/schema/shared/errors.ts
@@ -167,11 +167,9 @@ export class ArkErrors
 	readonly [arkKind] = "errors"
 
 	/**
-	 * Without this, `Array.prototype.map` / `filter` / `slice` / … allocate another
-	 * `ArkErrors` via species, so callbacks that return primitives (e.g.
-	 * `issues.map(i => i.message)` in Standard Schema consumers such as Nest)
-	 * would fill numeric indices with strings — then `JSON.stringify` invokes
-	 * {@link ArkErrors.toJSON} and must not assume every slot is an {@link ArkError}.
+	 * Inherited array methods (`map`, `filter`, `slice`, …) return a plain
+	 * `Array`, not another `ArkErrors`, so callbacks that return primitives
+	 * (e.g. `issues.map(i => i.message)`) cannot populate a new `ArkErrors` instance.
 	 */
 	static get [Symbol.species](): ArrayConstructor {
 		return Array
@@ -327,16 +325,10 @@ export class ArkErrors
 	}
 
 	/**
-	 * Serialize one indexed `issues` slot for `JSON.stringify`.
+	 * Serialize a single `issues[index]` for `JSON.stringify`.
 	 *
-	 * Ark only appends via {@link ArkErrors.add} (`ArkError`), but this value is
-	 * also {@link StandardSchemaV1.FailureResult.issues}, whose spec entries are
-	 * plain {@link StandardSchemaV1.Issue} shapes (message / optional path) with
-	 * no `toJSON` requirement. Consumers may stringify failure payloads; at
-	 * runtime the array remains an `Array` subclass, so userland or integrations
-	 * could theoretically append spec-shaped objects. Branching here keeps
-	 * `toJSON` aligned with that contract without assuming every slot is
-	 * {@link ArkError}.
+	 * Usually `ArkError` from `add`, but `issues` is also Standard Schema failure
+	 * issues: plain `{ message, path? }` values need not define `toJSON`.
 	 */
 	private static indexedIssueToJSON(issue: unknown): JsonObject {
 		if (issue === undefined) return { message: "undefined" }

--- a/ark/schema/shared/errors.ts
+++ b/ark/schema/shared/errors.ts
@@ -314,8 +314,29 @@ export class ArkErrors
 		return this
 	}
 
+	/**
+	 * Also Standard Schema `issues`; HTTP stacks may `JSON.stringify` this array,
+	 * so indexed entries must not assume {@link ArkError}.
+	 */
+	private static indexedIssueToJson(issue: unknown): JsonObject {
+		if (issue === undefined) return { message: "undefined" }
+		if (issue === null) return { message: "null" }
+		if (typeof issue !== "object") return { message: String(issue) }
+
+		const toJSON = (issue as { toJSON?: unknown }).toJSON
+		if (typeof toJSON === "function") return toJSON.call(issue)
+
+		const { message, path } = issue as Record<string, unknown>
+		if (typeof message === "string") {
+			if (path === undefined) return { message }
+			return { message, path } as JsonObject
+		}
+
+		return { message: String(issue) }
+	}
+
 	toJSON(): JsonArray {
-		return [...this.map(e => e.toJSON())]
+		return [...this.map(ArkErrors.indexedIssueToJson)]
 	}
 
 	toString(): string {

--- a/ark/schema/shared/errors.ts
+++ b/ark/schema/shared/errors.ts
@@ -324,36 +324,8 @@ export class ArkErrors
 		return this
 	}
 
-	/**
-	 * Serialize a single `issues[index]` for `JSON.stringify`.
-	 *
-	 * Usually `ArkError` from `add`, but `issues` is also Standard Schema failure
-	 * issues: plain `{ message, path? }` values need not define `toJSON`.
-	 */
-	private static indexedIssueToJSON(issue: unknown): JsonObject {
-		if (issue === undefined) return { message: "undefined" }
-		if (issue === null) return { message: "null" }
-		if (typeof issue !== "object") return { message: String(issue) }
-
-		const toJSON = (issue as { toJSON?: unknown }).toJSON
-		if (typeof toJSON === "function") {
-			// `ArkError#toJSON` returns a `JsonObject`. Exotic `toJSON` implementations
-			// that return non-records are out of scope here.
-			return toJSON.call(issue) as JsonObject
-		}
-
-		const { message, path } = issue as Record<string, unknown>
-		if (typeof message === "string") {
-			if (path === undefined) return { message }
-			if (Array.isArray(path)) return { message, path: path as Json }
-			return { message }
-		}
-
-		return { message: String(issue) }
-	}
-
 	toJSON(): JsonArray {
-		return [...this.map(ArkErrors.indexedIssueToJSON)]
+		return [...this.map(e => e.toJSON())]
 	}
 
 	toString(): string {

--- a/ark/schema/shared/errors.ts
+++ b/ark/schema/shared/errors.ts
@@ -7,6 +7,7 @@ import {
 	defineProperties,
 	flatMorph,
 	stringifyPath,
+	type Json,
 	type JsonArray,
 	type JsonObject,
 	type array,
@@ -315,28 +316,41 @@ export class ArkErrors
 	}
 
 	/**
-	 * Also Standard Schema `issues`; HTTP stacks may `JSON.stringify` this array,
-	 * so indexed entries must not assume {@link ArkError}.
+	 * Serialize one indexed `issues` slot for `JSON.stringify`.
+	 *
+	 * Ark only appends via {@link ArkErrors.add} (`ArkError`), but this value is
+	 * also {@link StandardSchemaV1.FailureResult.issues}, whose spec entries are
+	 * plain {@link StandardSchemaV1.Issue} shapes (message / optional path) with
+	 * no `toJSON` requirement. Consumers may stringify failure payloads; at
+	 * runtime the array remains an `Array` subclass, so userland or integrations
+	 * could theoretically append spec-shaped objects. Branching here keeps
+	 * `toJSON` aligned with that contract without assuming every slot is
+	 * {@link ArkError}.
 	 */
-	private static indexedIssueToJson(issue: unknown): JsonObject {
+	private static indexedIssueToJSON(issue: unknown): JsonObject {
 		if (issue === undefined) return { message: "undefined" }
 		if (issue === null) return { message: "null" }
 		if (typeof issue !== "object") return { message: String(issue) }
 
 		const toJSON = (issue as { toJSON?: unknown }).toJSON
-		if (typeof toJSON === "function") return toJSON.call(issue)
+		if (typeof toJSON === "function") {
+			// `ArkError#toJSON` returns a `JsonObject`. Exotic `toJSON` implementations
+			// that return non-records are out of scope here.
+			return toJSON.call(issue) as JsonObject
+		}
 
 		const { message, path } = issue as Record<string, unknown>
 		if (typeof message === "string") {
 			if (path === undefined) return { message }
-			return { message, path } as JsonObject
+			if (Array.isArray(path)) return { message, path: path as Json }
+			return { message }
 		}
 
 		return { message: String(issue) }
 	}
 
 	toJSON(): JsonArray {
-		return [...this.map(ArkErrors.indexedIssueToJson)]
+		return [...this.map(ArkErrors.indexedIssueToJSON)]
 	}
 
 	toString(): string {

--- a/ark/schema/shared/errors.ts
+++ b/ark/schema/shared/errors.ts
@@ -166,6 +166,17 @@ export class ArkErrors
 {
 	readonly [arkKind] = "errors"
 
+	/**
+	 * Without this, `Array.prototype.map` / `filter` / `slice` / … allocate another
+	 * `ArkErrors` via species, so callbacks that return primitives (e.g.
+	 * `issues.map(i => i.message)` in Standard Schema consumers such as Nest)
+	 * would fill numeric indices with strings — then `JSON.stringify` invokes
+	 * {@link ArkErrors.toJSON} and must not assume every slot is an {@link ArkError}.
+	 */
+	static get [Symbol.species](): ArrayConstructor {
+		return Array
+	}
+
 	protected ctx: Traversal
 
 	constructor(ctx: Traversal) {

--- a/ark/schema/shared/errors.ts
+++ b/ark/schema/shared/errors.ts
@@ -7,7 +7,6 @@ import {
 	defineProperties,
 	flatMorph,
 	stringifyPath,
-	type Json,
 	type JsonArray,
 	type JsonObject,
 	type array,


### PR DESCRIPTION
## Summary
- Set **`ArkErrors[Symbol.species]`** to **`Array`** so inherited array methods (`map`, `filter`, `slice`, …) allocate a **plain `Array`**, not another **`ArkErrors`**. This fixes the case where **`issues.map(issue => issue.message)`** could return an **`ArkErrors`** whose numeric indices held **strings** (callback results), which then broke **`JSON.stringify`** with **`TypeError: e.toJSON is not a function`** inside **`ArkErrors.prototype.toJSON`**.
- Add **regression tests**: **`Symbol.species`** / **`map` → `Array`**, plus a **Standard Schema** failure path that **`JSON.stringify`**s a realistic HTTP-style payload (`{ issues, messages }`).

## How the problem shows up
1. On validation failure, **`schema["~standard"].validate`** returns an **`ArkErrors`** instance; **`issues`** is the same value (an **`Array` subclass**).
2. Without **`[Symbol.species]`**, **`issues.map(…)`** allocates **another `ArkErrors`**, filling indices **`0..n-1`** with **callback return values** (e.g. **strings** from **`issue.message`**), not **`ArkError`** instances.
3. That value can end up in an HTTP error payload passed to **`JSON.stringify`**. **`ArkErrors`** defines **`toJSON`**, so serialization invokes **`ArkErrors.prototype.toJSON`** even when numeric slots are no longer **`ArkError`** objects.
4. **`ArkErrors#toJSON`** does **`this.map(e => e.toJSON())`** — strings have no **`toJSON`** → **`TypeError: e.toJSON is not a function`**, often surfacing as a **server error while building the response body** instead of a stable **client error** JSON payload.

## How this change fixes it
**`static get [Symbol.species](): ArrayConstructor { return Array }`** — array methods that create a new array now yield a **normal `Array`**, so **`issues.map(issue => issue.message)`** returns a plain array of strings. **`JSON.stringify`** on **`issues`** itself still goes through **`ArkErrors#toJSON`** and serializes **`ArkError`** instances as before; the failure mode was specifically **`map`** (and similar) reusing the subclass constructor for the result.

## Test plan
- [x] `Array methods allocate plain Array (Symbol.species), not ArkErrors`
- [x] `JSON.stringify round-trip via Standard Schema failure (e.g. HTTP error payload)`