### PR TITLE
refactor(repo): drop tsx, rely on native Node type stripping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,7 @@
 	"typescript.tsserver.experimental.enableProjectDiagnostics": true,
 	"typescript.tsdk": "./node_modules/typescript/lib",
 	// IF YOU UPDATE THE MOCHA CONFIG HERE, PLEASE ALSO UPDATE package.json/mocha AND ark/repo/mocha.jsonc
-	"mochaExplorer.nodeArgv": ["--conditions", "ark-ts", "--import", "tsx"],
+	"mochaExplorer.nodeArgv": ["--conditions", "ark-ts"],
 	// ignore attest since it requires type information
 	"mochaExplorer.ignore": ["ark/attest/**/*"],
 	"mochaExplorer.require": "ark/repo/mocha.globalSetup.ts",

--- a/ark/attest/__tests__/utils.ts
+++ b/ark/attest/__tests__/utils.ts
@@ -7,7 +7,7 @@ export const runThenGetContents = (templatePath: string): string => {
 	const tempPath = templatePath + ".temp.ts"
 	copyFileSync(templatePath, tempPath)
 	try {
-		shell(`node --import=tsx ${tempPath}`, {
+		shell(`node ${tempPath}`, {
 			cwd: dirName(),
 			env: {
 				ATTEST_failOnMissingSnapshots: "0"

--- a/ark/fast-check/package.json
+++ b/ark/fast-check/package.json
@@ -34,7 +34,7 @@
 	],
 	"scripts": {
 		"build": "ts ../repo/build.ts",
-		"test": "tsx ../repo/testPackage.ts"
+		"test": "node ../repo/testPackage.ts"
 	},
 	"dependencies": {
 		"arktype": "workspace:*",

--- a/ark/repo/mocha.package.jsonc
+++ b/ark/repo/mocha.package.jsonc
@@ -8,6 +8,6 @@
 {
 	"spec": ["__tests__/*.test.*"],
 	"ignore": "node_modules/**/*",
-	"node-option": ["conditions=ark-ts", "import=tsx"],
+	"node-option": ["conditions=ark-ts"],
 	"require": "../repo/mocha.globalSetup.ts"
 }

--- a/ark/repo/nodeOptions.js
+++ b/ark/repo/nodeOptions.js
@@ -1,12 +1,23 @@
 // @ts-check
 
-/** @param {number} major @returns {string} */
-function getFallbackReason(major) {
-	if (major >= 26) {
-		return "Node.js >= 26 does not allow --experimental-transform-types in NODE_OPTIONS; falling back to tsx..."
-	}
+// This repo contains no TypeScript syntax that requires *transformation*
+// (no runtime enums, parameter properties, or value-bearing namespaces — only
+// erasable `declare`/type-level forms), so native type *stripping* is
+// sufficient. That lets us avoid `--experimental-transform-types`, which Node
+// >= 26 rejects in NODE_OPTIONS.
 
-	return "--experimental-transform-types requires Node >= 22.7.0, falling back to tsx..."
+/** @param {number} major @param {number} minor @returns {boolean} */
+function stripsTypesByDefault(major, minor) {
+	// type stripping became the default (no flag) in 23.6.0, backported to 22.18.0
+	return (
+		major >= 24 || (major === 23 && minor >= 6) || (major === 22 && minor >= 18)
+	)
+}
+
+/** @param {number} major @param {number} minor @returns {boolean} */
+function stripsTypesBehindFlag(major, minor) {
+	// 22.6–22.17 and 23.0–23.5 can strip types, but only behind a flag
+	return (major === 22 && minor >= 6) || (major === 23 && minor < 6)
 }
 
 /**
@@ -15,13 +26,14 @@ function getFallbackReason(major) {
  * @returns {string}
  */
 function versionedFlagsFor(major, minor) {
-	const useExperimentalTransformTypes =
-		(major > 22 && major < 26) || (major === 22 && minor >= 7)
-	if (useExperimentalTransformTypes) {
-		return "--experimental-transform-types --no-warnings"
-	}
+	if (stripsTypesByDefault(major, minor)) return ""
 
-	console.log(getFallbackReason(major))
+	if (stripsTypesBehindFlag(major, minor))
+		return "--experimental-strip-types --no-warnings"
+
+	console.log(
+		"native TypeScript support requires Node >= 22.6.0, falling back to tsx..."
+	)
 	return "--import tsx"
 }
 
@@ -29,7 +41,8 @@ const [major, minor] = process.version.replace("v", "").split(".").map(Number)
 
 const versionedFlags = versionedFlagsFor(major, minor)
 
-export const nodeDevOptions = `${process.env.NODE_OPTIONS ?? ""} --conditions ark-ts ${versionedFlags}`
+export const nodeDevOptions =
+	`${process.env.NODE_OPTIONS ?? ""} --conditions ark-ts ${versionedFlags}`.trimEnd()
 
 export const addNodeDevOptions = extraOpts =>
-	(process.env.NODE_OPTIONS = `${nodeDevOptions} ${extraOpts ?? ""}`)
+	(process.env.NODE_OPTIONS = `${nodeDevOptions} ${extraOpts ?? ""}`.trimEnd())

--- a/ark/repo/nodeOptions.js
+++ b/ark/repo/nodeOptions.js
@@ -1,14 +1,33 @@
 // @ts-check
 
+/** @param {number} major @returns {string} */
+function getFallbackReason(major) {
+	if (major >= 26) {
+		return "Node.js >= 26 does not allow --experimental-transform-types in NODE_OPTIONS; falling back to tsx..."
+	}
+
+	return "--experimental-transform-types requires Node >= 22.7.0, falling back to tsx..."
+}
+
+/**
+ * @param {number} major
+ * @param {number} minor
+ * @returns {string}
+ */
+function versionedFlagsFor(major, minor) {
+	const useExperimentalTransformTypes =
+		(major > 22 && major < 26) || (major === 22 && minor >= 7)
+	if (useExperimentalTransformTypes) {
+		return "--experimental-transform-types --no-warnings"
+	}
+
+	console.log(getFallbackReason(major))
+	return "--import tsx"
+}
+
 const [major, minor] = process.version.replace("v", "").split(".").map(Number)
 
-const versionedFlags =
-	major > 22 || (major === 22 && minor >= 7) ?
-		"--experimental-transform-types --no-warnings"
-	:	(console.log(
-			"--experimental-transform-types requires Node >= 22.7.0, falling back to tsx..."
-		),
-		"--import tsx")
+const versionedFlags = versionedFlagsFor(major, minor)
 
 export const nodeDevOptions = `${process.env.NODE_OPTIONS ?? ""} --conditions ark-ts ${versionedFlags}`
 

--- a/ark/repo/nodeOptions.js
+++ b/ark/repo/nodeOptions.js
@@ -1,48 +1,15 @@
 // @ts-check
 
-// This repo contains no TypeScript syntax that requires *transformation*
-// (no runtime enums, parameter properties, or value-bearing namespaces — only
-// erasable `declare`/type-level forms), so native type *stripping* is
-// sufficient. That lets us avoid `--experimental-transform-types`, which Node
-// >= 26 rejects in NODE_OPTIONS.
-
-/** @param {number} major @param {number} minor @returns {boolean} */
-function stripsTypesByDefault(major, minor) {
-	// type stripping became the default (no flag) in 23.6.0, backported to 22.18.0
-	return (
-		major >= 24 || (major === 23 && minor >= 6) || (major === 22 && minor >= 18)
-	)
-}
-
-/** @param {number} major @param {number} minor @returns {boolean} */
-function stripsTypesBehindFlag(major, minor) {
-	// 22.6–22.17 and 23.0–23.5 can strip types, but only behind a flag
-	return (major === 22 && minor >= 6) || (major === 23 && minor < 6)
-}
-
-/**
- * @param {number} major
- * @param {number} minor
- * @returns {string}
- */
-function versionedFlagsFor(major, minor) {
-	if (stripsTypesByDefault(major, minor)) return ""
-
-	if (stripsTypesBehindFlag(major, minor))
-		return "--experimental-strip-types --no-warnings"
-
-	console.log(
-		"native TypeScript support requires Node >= 22.6.0, falling back to tsx..."
-	)
-	return "--import tsx"
-}
-
-const [major, minor] = process.version.replace("v", "").split(".").map(Number)
-
-const versionedFlags = versionedFlagsFor(major, minor)
+// Every Node version we support (see `engines.node`) strips TypeScript types
+// natively by default — no flag required. This repo also contains no syntax
+// that needs type *transformation* (no runtime enums, parameter properties, or
+// value-bearing namespaces — only erasable `declare`/type-level forms), so
+// stripping alone is sufficient and we pass no TS-related flags. Notably this
+// avoids `--experimental-transform-types`, which Node >= 26 rejects in
+// NODE_OPTIONS.
 
 export const nodeDevOptions =
-	`${process.env.NODE_OPTIONS ?? ""} --conditions ark-ts ${versionedFlags}`.trimEnd()
+	`${process.env.NODE_OPTIONS ?? ""} --conditions ark-ts`.trimEnd()
 
 export const addNodeDevOptions = extraOpts =>
 	(process.env.NODE_OPTIONS = `${nodeDevOptions} ${extraOpts ?? ""}`.trimEnd())

--- a/ark/type/__tests__/realWorld.test.ts
+++ b/ark/type/__tests__/realWorld.test.ts
@@ -1302,10 +1302,13 @@ Right: { x: number, y: number, + (undeclared): delete }`)
 
 	it("described input of morph", () => {
 		class ValidatedUserID {
+			readonly data: string
 			static fromString(value: string): ValidatedUserID {
 				return new ValidatedUserID(value)
 			}
-			private constructor(readonly data: string) {}
+			private constructor(data: string) {
+				this.data = data
+			}
 		}
 
 		const UserID = type("string")

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
 		"mocha": "11.7.4",
 		"prettier": "3.6.2",
 		"tsup": "8.5.0",
-		"tsx": "4.20.6",
 		"typescript": "catalog:",
 		"typescript-eslint": "8.46.1"
 	},
@@ -85,8 +84,7 @@
 		],
 		"ignore": "**/node_modules/**/*",
 		"node-option": [
-			"conditions=ark-ts",
-			"import=tsx"
+			"conditions=ark-ts"
 		],
 		"require": "./ark/repo/mocha.globalSetup.ts",
 		"timeout": 10000
@@ -109,7 +107,7 @@
 		"arrowParens": "avoid"
 	},
 	"engines": {
-		"node": ">=18",
+		"node": ">=22.18.0",
 		"pnpm": ">=10"
 	},
 	"packageManager": "pnpm@10.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       tsup:
         specifier: 8.5.0
         version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)
-      tsx:
-        specifier: 4.20.6
-        version: 4.20.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -8263,6 +8260,7 @@ snapshots:
   get-tsconfig@4.12.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   github-from-package@0.0.0:
     optional: true
@@ -10099,7 +10097,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   resolve@1.22.10:
     dependencies:
@@ -10668,6 +10667,7 @@ snapshots:
       get-tsconfig: 4.12.0
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:


### PR DESCRIPTION
### Summary

From Node **26** onward, `--experimental-transform-types` is **not allowed in `NODE_OPTIONS`**, so any `node` child process started after `addNodeDevOptions()` fails. This originally surfaced as a failing **`compatibility (ubuntu-latest, latest)`** check.

Instead of falling back to `tsx`, this leans entirely on Node's **native type stripping**, which is the default on every version we support. The repo contains no syntax that requires type *transformation* (only erasable `declare`/type-level forms — the `enum` in `ark/regex/state.ts` lives inside a `declare namespace`), so stripping alone is sufficient and **no loader or flag is needed anywhere**.

### Changes

- **`ark/repo/nodeOptions.js`**: collapsed to pass only `--conditions ark-ts` (no `--experimental-transform-types`, no `tsx`).
- **`engines.node`**: bumped `>=18` → `>=22.18.0` (unflagged stripping landed in the 22.x line at 22.18.0; also 23.6+/24+). Dev-only — the root package is `private`, and the published `arktype` package declares no `engines`, so library consumers are unaffected.
- **Dropped `tsx` entirely** — no test context needs it:
  - removed `import=tsx` from all three synced mocha configs (`package.json`, `ark/repo/mocha.package.jsonc`, `.vscode/settings.json`)
  - `ark/fast-check` test and the `@ark/attest` self-test spawn now run via plain `node`
  - removed the `tsx` devDependency
- **`ark/type/__tests__/realWorld.test.ts`**: de-sugared the one parameter property so the entire codebase is strip-compatible.

### Test plan

- [x] `testTyped` — **1703 passing** under native stripping, no tsx
- [x] `@ark/fast-check` integration — **56 passing** via `node ../repo/testPackage.ts`
- [x] `@ark/attest` snapPopulation / self-tests — **63 passing** (exercises the native `node` template spawn)
- [x] `nodeDevOptions` emits only `--conditions ark-ts`; prettier + eslint clean
- [ ] full Node matrix (lts / lts-1 / latest) via CI

### Notes

- `engine-strict` was intentionally **not** enabled — it risks failing installs on transitive-dependency engine mismatches; the `engines` bump alone documents the requirement (pnpm warns by default). Easy to add later if desired.
- The Node versions CI tests (`lts/*`, `lts/-1`, `latest`) all strip by default, so the previous version-ladder branches were never exercised in CI anyway.
