### PR TITLE
fix: remove invalid secrets: inherit from pullfrog workflow

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -11,7 +11,6 @@ on:
       prompt:
         description: Agent prompt
         type: string
-    secrets: inherit
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

- Every `push`-triggered Pullfrog run was failing instantly (0s, no jobs) with GitHub's "invalid workflow file" error, while `workflow_dispatch` runs succeeded.
- Root cause: `secrets: inherit` was placed under `on.workflow_call` in `.github/workflows/pullfrog.yml`. `inherit` is only valid at the **caller** job level (`jobs.<id>.secrets: inherit`); under `on.workflow_call.secrets` GitHub expects a map of named secret definitions, so the file failed parse-time validation.
- This removes the offending line, matching [Pullfrog's canonical template](https://github.com/pullfrog/action). Secrets still reach the agent via the existing step-level `env:` block, so there is no behavior change for the working `workflow_dispatch` runs.

## Test plan

- [ ] Confirm push to this branch no longer produces an instant failed "Pullfrog" run.
- [ ] Confirm `workflow_dispatch` Pullfrog runs continue to succeed.

Made with [Cursor](https://cursor.com)