### PR TITLE
fix(regex): include the empty string when a zero-min quantifier applies to a number pattern

### DIFF
--- a/ark/regex/__tests__/regex.test.ts
+++ b/ark/regex/__tests__/regex.test.ts
@@ -223,6 +223,17 @@ contextualize(() => {
 			attest<Regex<"ac" | `ab${string}c`, {}>>(S)
 		})
 
+		// https://github.com/arktypeio/arktype/issues/1625
+		it("* over a digit class allows the empty string", () => {
+			const S = regex("^(\\d*)$")
+			attest<Regex<"" | `${number}`, { captures: ["" | `${number}`] }>>(S)
+		})
+
+		it("? over a digit class allows the empty string", () => {
+			const S = regex("^(\\d?)$")
+			attest<Regex<"" | `${number}`, { captures: ["" | `${number}`] }>>(S)
+		})
+
 		it("unmatched ?", () => {
 			// @ts-expect-error
 			attest(() => regex("?")).type.errors(writeUnmatchedQuantifierError("?"))

--- a/ark/regex/quantify.ts
+++ b/ark/regex/quantify.ts
@@ -98,9 +98,13 @@ type tryFastPath<
 	max extends number | null
 > =
 	max extends 0 ? ""
-	: // repeating string or `${number}` any number of times will not change the type
+	: // repeating string or `${number}` any number of times will not change the
+	// type, but zero repetitions produce "", which `${number}` does not include
 	string extends pattern ? string
-	: `${number}` extends pattern ? `${number}`
+	: `${number}` extends pattern ?
+		min extends 0 ?
+			"" | `${number}`
+		:	`${number}`
 	: min extends 0 ?
 		max extends 1 ? "" | pattern
 		: max extends number ? loopFromZero<pattern, max, "", []>


### PR DESCRIPTION
Fixes #1625

### Problem

`regex("(\\d*)")` types the capture group as `` `${number}` ``, which excludes the empty string even though `*` matches zero repetitions. `?` has the same problem (`regex("(\\d?)")` → `` `${number}` ``).

The `tryFastPath` branch in `ark/regex/quantify.ts` returns early for number-like patterns on the premise that repeating `` `${number}` `` does not change the type — true for one or more repetitions, but zero repetitions produce `""`, which `` `${number}` `` does not include. The early return runs before the `min extends 0` handling, so every zero-min quantifier (`*`, `?`, `{0,n}`) over a number pattern drops the empty branch. The `string` fast path is unaffected because `string` already contains `""`.

### Fix

Make the number fast path min-aware: zero-min quantifiers produce `"" | `${number}` `` and quantifiers with `min >= 1` keep the existing `` `${number}` `` result.

### Tests

Two type-level tests (`*` and `?` over `\d` in a capture group) fail on `main` with

```
+ 'Regex<`${number}`, { captures: [`${number}`]; }>'
- 'Regex<`${number}` | "", { captures: [`${number}` | ""]; }>'
```

and pass with this change. Full mocha run: 1766 passing; the 2 failures in `ark/attest/__tests__/snapPopulation.test.ts` reproduce identically on a clean checkout of `main` and are unrelated. Prettier and ESLint clean on the changed files.
