### PR TITLE
docs(fast-check): add package README and integrations docs

### DIFF
--- a/ark/docs/content/docs/integrations/index.mdx
+++ b/ark/docs/content/docs/integrations/index.mdx
@@ -64,6 +64,42 @@ const User = jsonSchemaToType({
 
 See the [`@ark/json-schema` README](https://github.com/arktypeio/arktype/tree/main/ark/json-schema) for more details and limitations.
 
+### fast-check
+
+The `@ark/fast-check` package converts ArkType schemas to [`fast-check`](https://fast-check.dev) arbitraries for property-based testing:
+
+```sh
+pnpm add @ark/fast-check fast-check
+```
+
+Import `arkToArbitrary` from `@ark/fast-check`, then pass any `Type` to your `fast-check` properties:
+
+```ts
+// @noErrors
+import { type } from "arktype"
+
+declare const arkToArbitrary: (schema: type.Any) => unknown
+declare const assert: (property: unknown) => void
+declare const property: (
+	arbitrary: unknown,
+	predicate: (value: unknown) => boolean
+) => unknown
+
+const User = type({
+	name: "string",
+	"age?": "number.integer >= 0"
+})
+
+assert(
+	property(arkToArbitrary(User), value => {
+		User.assert(value)
+		return true
+	})
+)
+```
+
+This lets tests generate inputs from the same schema they validate against. See the [`@ark/fast-check` README](https://github.com/arktypeio/arktype/tree/main/ark/fast-check) for supported schemas and limitations.
+
 ### tRPC
 
 ArkType can easily be used with tRPC:

--- a/ark/docs/content/docs/integrations/meta.json
+++ b/ark/docs/content/docs/integrations/meta.json
@@ -3,6 +3,7 @@
 	"pages": [
 		"[Standard Schema](/docs/integrations#standard-schema)",
 		"[JSON Schema](/docs/integrations#json-schema)",
+		"[fast-check](/docs/integrations#fast-check)",
 		"[tRPC](/docs/integrations#trpc)",
 		"[drizzle](/docs/integrations#drizzle)",
 		"[react-hook-form](/docs/integrations#react-hook-form)",

--- a/ark/docs/public/llms.txt
+++ b/ark/docs/public/llms.txt
@@ -2796,6 +2796,42 @@ const User = jsonSchemaToType({
 
 See the [`@ark/json-schema` README](https://github.com/arktypeio/arktype/tree/main/ark/json-schema) for more details and limitations.
 
+### fast-check
+
+The `@ark/fast-check` package converts ArkType schemas to [`fast-check`](https://fast-check.dev) arbitraries for property-based testing:
+
+```sh
+pnpm add @ark/fast-check fast-check
+```
+
+Import `arkToArbitrary` from `@ark/fast-check`, then pass any `Type` to your `fast-check` properties:
+
+```ts
+// @noErrors
+import { type } from "arktype"
+
+declare const arkToArbitrary: (schema: type.Any) => unknown
+declare const assert: (property: unknown) => void
+declare const property: (
+	arbitrary: unknown,
+	predicate: (value: unknown) => boolean
+) => unknown
+
+const User = type({
+	name: "string",
+	"age?": "number.integer >= 0"
+})
+
+assert(
+	property(arkToArbitrary(User), value => {
+		User.assert(value)
+		return true
+	})
+)
+```
+
+This lets tests generate inputs from the same schema they validate against. See the [`@ark/fast-check` README](https://github.com/arktypeio/arktype/tree/main/ark/fast-check) for supported schemas and limitations.
+
 ### tRPC
 
 ArkType can easily be used with tRPC:

--- a/ark/fast-check/README.md
+++ b/ark/fast-check/README.md
@@ -1,0 +1,48 @@
+# @ark/fast-check
+
+Generate [`fast-check`](https://fast-check.dev) arbitraries from ArkType schemas.
+
+## Install
+
+Install it alongside `fast-check`:
+
+```sh
+pnpm add arktype @ark/fast-check fast-check
+```
+
+## Usage
+
+`arkToArbitrary` accepts an ArkType `Type` and returns a `fast-check` `Arbitrary` that generates values matching that schema:
+
+```ts
+import { arkToArbitrary } from "@ark/fast-check"
+import { type } from "arktype"
+import { assert, property } from "fast-check"
+
+const User = type({
+	name: "string",
+	"age?": "number.integer >= 0"
+})
+
+assert(
+	property(arkToArbitrary(User), value => {
+		const user = User.assert(value)
+		return user.age === undefined || user.age >= 0
+	})
+)
+```
+
+This is useful when you want property-based tests to cover the same input space that your runtime validators accept.
+
+## Supported Schemas
+
+`@ark/fast-check` supports common ArkType definitions including:
+
+- primitive domains like `string`, `number`, `bigint`, `boolean`, `symbol` and `unknown`
+- unions and literals
+- numeric, string, array and date constraints
+- arrays, tuples and variadic tuples
+- object structures, optional properties and index signatures
+- finite aliases and morph inputs
+
+Unsupported schema combinations throw when creating the arbitrary, so test failures point to the unsupported definition before the property runs.


### PR DESCRIPTION
## Summary
- Add a package README for `@ark/fast-check` with install steps, `arkToArbitrary` usage, supported schema categories, and unsupported-schema behavior.
- Document the integration on arktype.io under Integrations, including sidebar navigation.
- Update `llms.txt` so the new integrations content is included in exported docs.

Closes #1243

## Test plan
- [x] `pnpm exec prettier --check` on edited formattable files
- [x] `pnpm --filter @ark/docs build`

Made with [Cursor](https://cursor.com)