### PR TITLE
fix(type): wire up `type.fn.raw` at runtime

### DIFF
--- a/ark/type/__tests__/fn.test.ts
+++ b/ark/type/__tests__/fn.test.ts
@@ -316,7 +316,10 @@ contextualize(() => {
 	})
 
 	it("raw", () => {
-		const len = type.fn.raw("string | unknown[]")((s: string) => s.length)
+		// raw has no type-level inference, so it's returned as an untyped parser
+		const len = type.fn.raw("string | unknown[]")((s: string) => s.length) as (
+			data: unknown
+		) => number
 
 		attest(len("foo")).equals(3)
 		attest(() => len(1)).throws.snap(

--- a/ark/type/__tests__/fn.test.ts
+++ b/ark/type/__tests__/fn.test.ts
@@ -315,6 +315,15 @@ contextualize(() => {
 		attest(f.name).snap("bound typed originalName")
 	})
 
+	it("raw", () => {
+		const len = type.fn.raw("string | unknown[]")((s: string) => s.length)
+
+		attest(len("foo")).equals(3)
+		attest(() => len(1)).throws.snap(
+			"TraversalError: value at [0] must be a string or an object (was a number)"
+		)
+	})
+
 	it("arg submodule completions", () => {
 		// @ts-expect-error
 		attest(() => type.fn("string.nu")).completions({

--- a/ark/type/fn.ts
+++ b/ark/type/fn.ts
@@ -73,35 +73,37 @@ type FnParserAttachments = Omit<FnParser, never>
 
 export class InternalFnParser extends Callable<(...args: unknown[]) => Fn> {
 	constructor($: InternalScope) {
-		const attach: FnParserAttachments = {
-			$: $ as never,
-			raw: $.fn
+		const parse = (...signature: unknown[]) => {
+			const returnOperatorIndex = signature.indexOf(":")
+			const lastParamIndex =
+				returnOperatorIndex === -1 ?
+					signature.length - 1
+				:	returnOperatorIndex - 1
+
+			const paramDefs = signature.slice(0, lastParamIndex + 1)
+
+			const paramTuple = $.parse(paramDefs).assertHasKind("intersection")
+
+			let returnType: BaseRoot = $.intrinsic.unknown
+
+			if (returnOperatorIndex !== -1) {
+				if (returnOperatorIndex !== signature.length - 2)
+					return throwParseError(badFnReturnTypeMessage)
+				returnType = $.parse(signature[returnOperatorIndex + 1])
+			}
+
+			return (impl: Fn) => new InternalTypedFn(impl, paramTuple, returnType)
 		}
 
-		super(
-			(...signature) => {
-				const returnOperatorIndex = signature.indexOf(":")
-				const lastParamIndex =
-					returnOperatorIndex === -1 ?
-						signature.length - 1
-					:	returnOperatorIndex - 1
+		// `raw` is an alias of `fn` itself with no type-level validation. It must
+		// reference `parse` directly rather than `$.fn`, which is still being
+		// constructed (and thus `undefined`) at this point.
+		const attach: FnParserAttachments = {
+			$: $ as never,
+			raw: parse
+		}
 
-				const paramDefs = signature.slice(0, lastParamIndex + 1)
-
-				const paramTuple = $.parse(paramDefs).assertHasKind("intersection")
-
-				let returnType: BaseRoot = $.intrinsic.unknown
-
-				if (returnOperatorIndex !== -1) {
-					if (returnOperatorIndex !== signature.length - 2)
-						return throwParseError(badFnReturnTypeMessage)
-					returnType = $.parse(signature[returnOperatorIndex + 1])
-				}
-
-				return (impl: Fn) => new InternalTypedFn(impl, paramTuple, returnType)
-			},
-			{ attach }
-		)
+		super(parse, { attach })
 	}
 }
 

--- a/ark/type/fn.ts
+++ b/ark/type/fn.ts
@@ -100,7 +100,7 @@ export class InternalFnParser extends Callable<(...args: unknown[]) => Fn> {
 		// constructed (and thus `undefined`) at this point.
 		const attach: FnParserAttachments = {
 			$: $ as never,
-			raw: parse
+			raw: parse as never
 		}
 
 		super(parse, { attach })


### PR DESCRIPTION
Closes #1609

`type.fn.raw` is typed as a function (an alias of `fn` with no type-level validation), but at runtime it's always `undefined`, so calling it throws `type.fn.raw is not a function`:

```ts
import { type } from "arktype"

type.fn.raw() // throws: type.fn.raw is not a function
```

### Cause

`InternalFnParser` builds its `attach` object with `raw: $.fn`, but `$.fn` is the very `InternalFnParser` instance being constructed (`scope.fn = new InternalFnParser(this)`), so it's still `undefined` at that point. `Callable` applies `attach` with `Object.assign`, which copies the value, so `raw` permanently captures `undefined` (a lazy getter wouldn't help either, since `Object.assign` evaluates it).

### Fix

Extract the parser body into a local `parse` function and reference it for both the callable body and `raw`. This removes the dependency on the half-initialized scope — `raw` and `fn` now point at the same parser, which matches the documented "alias of `fn`" behavior.

### Tests

Added a `raw` case to `ark/type/__tests__/fn.test.ts` asserting it parses, runs, and validates like `fn` (including the same traversal error on bad input).