### PR TITLE
Fix private alias precompilation

### DIFF
--- a/ark/schema/scope.ts
+++ b/ark/schema/scope.ts
@@ -181,13 +181,14 @@ const precompile = (references: readonly BaseNode[]): void =>
 
 const bindPrecompilation = (
 	references: readonly BaseNode[],
-	precompiler: CompiledFunction<() => PrecompiledReferences>
+	precompiler: CompiledFunction<() => PrecompiledReferences>,
+	owningScope?: BaseScope
 ): void => {
 	const precompilation = precompiler.write(rootScopeFnName, 4)
 	const compiledTraversals = precompiler.compile()()
 
 	for (const node of references) {
-		if (node.precompilation) {
+		if (node.precompilation && (!owningScope || node.$ !== owningScope)) {
 			// if node has already been bound to another scope or anonymous type, don't rebind it
 			continue
 		}
@@ -642,7 +643,7 @@ export abstract class BaseScope<$ extends {} = {}> {
 			if (!this.resolvedConfig.jitless) {
 				const precompiler = precompileReferences(this.references)
 				this.precompilation = precompiler.write(rootScopeFnName, 4)
-				bindPrecompilation(this.references, precompiler)
+				bindPrecompilation(this.references, precompiler, this)
 			}
 			this.resolved = true
 		}

--- a/ark/type/__tests__/realWorld.test.ts
+++ b/ark/type/__tests__/realWorld.test.ts
@@ -1488,6 +1488,31 @@ date3 must be a parsable date (was "")`)
 		attest(result).equals(component)
 	})
 
+	// https://github.com/arktypeio/arktype/issues/1362
+	it("cyclic discriminated union with private alias", () => {
+		const componentModule = type.module({
+			"#tabsItem": {
+				id: "string",
+				title: "component",
+				content: "component"
+			},
+			tabs: {
+				type: "'tabs'",
+				items: "tabsItem[]"
+			},
+			component: "string | tabs"
+		})
+		const componentSchema = componentModule.component
+
+		const component: typeof componentSchema.infer = {
+			type: "tabs",
+			items: []
+		}
+
+		// previously threw "TypeError: this.tabs1Apply is not a function"
+		attest(componentSchema(component)).equals(component)
+	})
+
 	// https://github.com/arktypeio/arktype/issues/1209
 	it("cyclic discriminated union issue 3", () => {
 		const $ = scope({


### PR DESCRIPTION
Fixes #1362.

## Summary
- Rebind precompiled traversal functions for nodes owned by a scope when the scope is exported, so aliases that were compiled during cyclic scope resolution do not keep stale references to unresolved context ids.
- Add a regression test for a cyclic discriminated union that references a private alias.

## Tests
- `pnpm exec mocha --no-config --no-package --node-option conditions=ark-ts --node-option import=tsx --require ./ark/repo/mocha.globalSetup.ts ark/type/__tests__/realWorld.test.ts --skipTypes`
- `pnpm exec mocha --no-config --no-package --node-option conditions=ark-ts --node-option import=tsx --require ./ark/repo/mocha.globalSetup.ts ark/type/__tests__/scope.test.ts ark/type/__tests__/discrimination.test.ts --skipTypes`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm typecheckRepo`
- `pnpm exec prettier --check ark/schema/scope.ts ark/type/__tests__/realWorld.test.ts`