### PR TITLE
release: arktype 2.2.2 + dependents

### DIFF
--- a/ark/attest/package.json
+++ b/ark/attest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/attest",
-	"version": "0.56.1",
+	"version": "0.56.2",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/fast-check/package.json
+++ b/ark/fast-check/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/fast-check",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/fs/package.json
+++ b/ark/fs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/fs",
-	"version": "0.56.0",
+	"version": "0.56.1",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/json-schema/package.json
+++ b/ark/json-schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/json-schema",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"license": "MIT",
 	"authors": [
 		{

--- a/ark/regex/package.json
+++ b/ark/regex/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arkregex",
 	"description": "A drop-in replacement for new RegExp() with types",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/schema/package.json
+++ b/ark/schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/schema",
-	"version": "0.56.0",
+	"version": "0.56.1",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -1,5 +1,15 @@
 # arktype
 
+## 2.2.2
+
+### Fix precompilation of private aliases
+
+A private alias referenced only within its own scope is no longer skipped during JIT precompilation, so its optimized traversal is bound correctly instead of falling back to the unbound reference.
+
+### Harden `ArkErrors` JSON serialization
+
+`ArkErrors` doubles as a Standard Schema `issues` array, so `JSON.stringify` no longer assumes every indexed entry is an `ArkError` with a `toJSON` method (e.g. plain issue-shaped entries from other validators). Inherited array methods (`map`, `filter`, `slice`, …) now return a plain `Array` via `Symbol.species`, preventing callbacks that return primitives from producing a malformed `ArkErrors`.
+
 ## 2.2.1
 
 ### Improve regex inference for zero-min quantifiers on numeric patterns

--- a/ark/type/package.json
+++ b/ark/type/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arktype",
 	"description": "TypeScript's 1:1 validator, optimized from editor to runtime",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/ark/util/package.json
+++ b/ark/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/util",
-	"version": "0.56.0",
+	"version": "0.56.1",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/util/registry.ts
+++ b/ark/util/registry.ts
@@ -8,7 +8,7 @@ import { FileConstructor, objectKindOf } from "./objectKinds.ts"
 // recent node versions (https://nodejs.org/api/esm.html#json-modules).
 
 // For now, we assert this matches the package.json version via a unit test.
-export const arkUtilVersion = "0.56.0"
+export const arkUtilVersion = "0.56.1"
 
 export const initialRegistryContents = {
 	version: arkUtilVersion,


### PR DESCRIPTION
Cuts a patch release bundling the three PRs merged today.

## Included
- **#1620** — refactor(repo): drop tsx, rely on native Node type stripping *(fixes the Node 26 / `latest` CI failure)*
- **#1632** — fix private alias precompilation
- **#1619** — fix(schema): avoid JSON.stringify crashes on ArkErrors issues slots

## Changes
- Added `arktype` **2.2.2** CHANGELOG entry covering the two user-facing fixes (both land via `@ark/schema`).
- Patch-bumped the core published packages:

| Package | From | To |
|---|---|---|
| arktype | 2.2.1 | 2.2.2 |
| @ark/schema | 0.56.0 | 0.56.1 |
| @ark/util | 0.56.0 | 0.56.1 |
| @ark/fs | 0.56.0 | 0.56.1 |
| @ark/attest | 0.56.1 | 0.56.2 |
| @ark/json-schema | 0.0.5 | 0.0.6 |
| arkregex | 0.0.6 | 0.0.7 |
| @ark/fast-check | 0.0.12 | 0.0.13 |

`arkdark` and `arkthemes` (editor extension + themes, separate 6.x line) were left untouched — say the word if you want those bumped too. Workspace deps resolve via `workspace:*`/`link:`, so no lockfile change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)