### PR TITLE
fix(type): preserve escaped backslash in regex string literals

### DIFF
--- a/ark/type/__tests__/regex.test.ts
+++ b/ark/type/__tests__/regex.test.ts
@@ -106,4 +106,39 @@ contextualize(() => {
 			}>
 		>(T)
 	})
+
+	describe("escaped backslash", () => {
+		// note: in a TS string, "\\\\d" is two literal backslashes followed by
+		// "d", i.e. the four characters `\`, `\`, `d` reach the parser, which is
+		// the regex source for a literal backslash + "d" (not the digit class)
+		it("string literal matches RegExp instance", () => {
+			const FromString = type("/^\\\\d$/")
+			const FromInstance = type(/^\\d$/)
+			attest(FromString.json).equals(FromInstance.json)
+		})
+
+		it("preserves literal backslash", () => {
+			const T = type("/^\\\\d$/")
+			attest(T.allows("\\d")).equals(true)
+			attest(T.allows("5")).equals(false)
+		})
+
+		it("lone escaped backslash", () => {
+			const T = type("/^\\\\$/")
+			attest(T.allows("\\")).equals(true)
+		})
+
+		it("single-backslash class still works", () => {
+			// "\\d" is a single backslash + "d", i.e. the digit-class metachar
+			const T = type("/^\\d+$/")
+			attest(T.allows("123")).equals(true)
+			attest(T.allows("abc")).equals(false)
+		})
+
+		it("escaped terminator preserved", () => {
+			const T = type("/^a\\/b$/")
+			attest(T.json).snap({ domain: "string", pattern: ["^a/b$"] })
+			attest(T.allows("a/b")).equals(true)
+		})
+	})
 })

--- a/ark/type/parser/shift/operand/enclosed.ts
+++ b/ark/type/parser/shift/operand/enclosed.ts
@@ -1,5 +1,6 @@
 import { rootSchema } from "@ark/schema"
 import {
+	Backslash,
 	isKeyOf,
 	throwParseError,
 	type ErrorMessage,
@@ -36,7 +37,11 @@ export const parseEnclosed = (
 	enclosing: EnclosingStartToken
 ): void => {
 	const enclosed = s.scanner.shiftUntilEscapable(
-		untilLookaheadIsClosing[enclosingTokens[enclosing]]
+		untilLookaheadIsClosing[enclosingTokens[enclosing]],
+		// within a regex literal, `\\` is a literal backslash and must be
+		// preserved verbatim in the pattern source; collapsing it to a single
+		// backslash would corrupt the regex (e.g. `\\d` -> `\d` digit class)
+		enclosing in enclosingRegexTokens ? Backslash : ""
 	)
 	if (s.scanner.lookahead === "")
 		return s.error(writeUnterminatedEnclosedMessage(enclosed, enclosing))
@@ -84,7 +89,7 @@ export type parseEnclosed<
 	Scanner.shiftUntilEscapable<
 		unscanned,
 		EnclosingTokens[enclosingStart],
-		""
+		enclosingStart extends EnclosingRegexToken ? Backslash : ""
 	> extends Scanner.shiftResult<infer scanned, infer nextUnscanned> ?
 		_parseEnclosed<s, enclosingStart, scanned, nextUnscanned>
 	:	never

--- a/ark/util/scanner.ts
+++ b/ark/util/scanner.ts
@@ -38,13 +38,17 @@ export class Scanner<lookahead extends string = string> {
 		return shifted
 	}
 
-	shiftUntilEscapable(condition: Scanner.UntilCondition): string {
+	shiftUntilEscapable(
+		condition: Scanner.UntilCondition,
+		escapeEscape: typeof Backslash | "" = ""
+	): string {
 		let shifted = ""
 		while (this.lookahead) {
 			if (this.lookahead === Backslash) {
 				this.shift()
 				if (condition(this, shifted)) shifted += this.shift()
-				else if (this.lookahead === Backslash) shifted += this.shift()
+				else if (this.lookahead === Backslash)
+					shifted += `${escapeEscape}${this.shift()}`
 				else shifted += `${Backslash}${this.shift()}`
 			} else if (condition(this, shifted)) break
 			else shifted += this.shift()


### PR DESCRIPTION
A regex written as a string literal loses escaped backslashes, so a pattern that should match a literal backslash is compiled as a metacharacter class and validates the wrong values. The string-literal form and the equivalent `RegExp`-instance form disagree, even though the docs treat them as equivalent.

## Repro

A regex matching a literal backslash followed by `d` is `/^\\d$/` as a `RegExp`. Written as a string literal the backslashes double again, so it becomes `"/^\\\\d$/"`.

```ts
import { type } from "arktype"

const FromInstance = type(/^\\d$/)     // literal backslash + d
const FromString = type("/^\\\\d$/")   // same intent, written as a string

FromInstance.allows("\\d")  // true   ("\\d" is the two character string: backslash, d)
FromString.allows("\\d")    // actual false, expected true
FromString.allows("5")      // actual true,  expected false
```

`FromString` is compiled as the digit class `\d` instead of a literal backslash plus `d`, so it rejects the value it should accept and accepts the value it should reject. `FromInstance`, which does not go through the string scanner, is correct, so the two forms diverge for the same intended pattern.

## Root cause

Both forms end in `new RegExp(source)`, but the string-literal path reads the source between the slashes with `Scanner.shiftUntilEscapable`, which collapses every `\\` into a single `\`. That rule is correct for a JS string literal, where `\\` denotes one backslash. It is wrong for a regex source: there `\\` is a literal backslash while `\d`, `\b`, `\w` are metacharacters, so collapsing turns a literal backslash into a metacharacter and changes what the pattern accepts.

## Fix

Add an optional `escapeEscape` argument to `shiftUntilEscapable`. For regex tokens the parser emits `\\` instead of collapsing it, keeping the pattern source equal to the `RegExp`-instance form. The change is applied in both the runtime parser and its type-level twin, so runtime validation and inferred types stay in agreement. Quoted-string and date literals are unchanged and still collapse `\\`; escaped terminators (`\/`) and single-backslash classes (`\d`, `\w`, `\t`) are unaffected.

## Authority

A regex literal's content is a regex source, not a JS string, so `\\` in it means one literal backslash. arktype's own `RegExp`-instance path (`type(/^\\d$/)`) already preserves this, and the docs treat `type("/regex/")` as equivalent to the corresponding `RegExp`, so the string form must produce the same pattern. The string scanner instead applied JS-string un-escaping to the regex source, which is the divergence this fixes.

## Tests

Added cases in `ark/type/__tests__/regex.test.ts` covering string-literal vs `RegExp`-instance parity, literal-backslash acceptance, a lone escaped backslash, and regression guards for single-backslash classes and escaped terminators. Verified red on the current base (the parity and backslash assertions fail without the parser change) and green with it. Full package suite passes (1774 passing; the 2 failing `snapPopulation` cases are pre-existing under `--skipTypes` and unrelated to this change).
