### PR TITLE
release: arktype 2.2.3 + dependents

### DIFF
--- a/ark/attest/package.json
+++ b/ark/attest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/attest",
-	"version": "0.56.2",
+	"version": "0.56.3",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/fast-check/package.json
+++ b/ark/fast-check/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/fast-check",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/fs/package.json
+++ b/ark/fs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/fs",
-	"version": "0.56.1",
+	"version": "0.56.2",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/json-schema/package.json
+++ b/ark/json-schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/json-schema",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"license": "MIT",
 	"authors": [
 		{

--- a/ark/regex/package.json
+++ b/ark/regex/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arkregex",
 	"description": "A drop-in replacement for new RegExp() with types",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/schema/package.json
+++ b/ark/schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/schema",
-	"version": "0.56.1",
+	"version": "0.56.2",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/type/CHANGELOG.md
+++ b/ark/type/CHANGELOG.md
@@ -1,5 +1,23 @@
 # arktype
 
+## 2.2.3
+
+### Fix `type.fn.raw` throwing at runtime
+
+`type.fn.raw` is documented as an untyped alias of `type.fn`, but was `undefined` at runtime and threw `type.fn.raw is not a function` when called. It now references the underlying parser directly, so it parses, runs, and validates like `type.fn` without type-level inference. Thanks to @aarsh767.
+
+### Anchor versioned UUID validation
+
+`string.uuid` no longer accepts strings that merely contain a UUID. The internal `#versioned` pattern is now anchored like the individual version keywords, so leading or trailing content is rejected. Thanks to @WolfieLeader.
+
+### Fix inferred output of `declare`d morphs
+
+The output side of a `declare`d definition now wraps its preinferred value in `Out<...>`, matching the inference of the equivalent definition without `declare`. Thanks to @eralmansouri.
+
+### Allow `Object.prototype` method names as keys
+
+Keys like `constructor`, `toString`, and `hasOwnProperty` are no longer incorrectly reported as duplicate keys, since duplicate detection now uses a prototype-free record. Thanks to @kaigritun.
+
 ## 2.2.2
 
 ### Fix precompilation of private aliases

--- a/ark/type/package.json
+++ b/ark/type/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arktype",
 	"description": "TypeScript's 1:1 validator, optimized from editor to runtime",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/ark/util/package.json
+++ b/ark/util/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ark/util",
-	"version": "0.56.1",
+	"version": "0.56.2",
 	"license": "MIT",
 	"author": {
 		"name": "David Blass",

--- a/ark/util/registry.ts
+++ b/ark/util/registry.ts
@@ -8,7 +8,7 @@ import { FileConstructor, objectKindOf } from "./objectKinds.ts"
 // recent node versions (https://nodejs.org/api/esm.html#json-modules).
 
 // For now, we assert this matches the package.json version via a unit test.
-export const arkUtilVersion = "0.56.1"
+export const arkUtilVersion = "0.56.2"
 
 export const initialRegistryContents = {
 	version: arkUtilVersion,


### PR DESCRIPTION
Bumps all publishable packages by one patch and documents the fixes merged since 2.2.2.

## Changelog (arktype 2.2.3)

- **Fix `type.fn.raw` throwing at runtime** — was `undefined` and threw; now aliases the real parser. #1631, thanks @aarsh767
- **Anchor versioned UUID validation** — `string.uuid` no longer accepts strings that merely contain a UUID. #1602, thanks @WolfieLeader
- **Fix inferred output of `declare`d morphs** — output side now wraps in `Out<...>` to match non-`declare`d inference. #1579, thanks @eralmansouri
- **Allow `Object.prototype` method names as keys** — `constructor`/`toString`/`hasOwnProperty` no longer flagged as duplicate keys. #1586, thanks @kaigritun

## Version bumps

| package | version |
|---|---|
| arktype | 2.2.2 → 2.2.3 |
| @ark/schema | 0.56.1 → 0.56.2 |
| @ark/util | 0.56.1 → 0.56.2 |
| @ark/fs | 0.56.1 → 0.56.2 |
| @ark/attest | 0.56.2 → 0.56.3 |
| @ark/json-schema | 0.0.6 → 0.0.7 |
| arkregex | 0.0.7 → 0.0.8 |
| @ark/fast-check | 0.0.13 → 0.0.14 |

Docs-only merges since 2.2.2 (#1472, #1585, #1501) are intentionally omitted from the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qk4c4vPUecBDYbd4p3yE1H