### PR TITLE
Fix recursive aliases with Record references

### DIFF
--- a/ark/schema/scope.ts
+++ b/ark/schema/scope.ts
@@ -755,13 +755,20 @@ export class SchemaScope<$ extends {} = {}> extends BaseScope<$> {
 const bootstrapAliasReferences = (resolution: BaseRoot | GenericRoot) => {
 	const aliases = resolution.references.filter(node => node.hasKind("alias"))
 	for (const aliasNode of aliases) {
-		Object.assign(aliasNode.referencesById, aliasNode.resolution.referencesById)
+		addReferences(aliasNode.referencesById, aliasNode.resolution.referencesById)
 		for (const ref of resolution.references) {
 			if (aliasNode.id in ref.referencesById)
-				Object.assign(ref.referencesById, aliasNode.referencesById)
+				addReferences(ref.referencesById, aliasNode.referencesById)
 		}
 	}
 	return resolution
+}
+
+const addReferences = (
+	base: BaseNode["referencesById"],
+	references: BaseNode["referencesById"]
+) => {
+	for (const id in references) base[id] ??= references[id]
 }
 
 const resolutionsToJson = (resolutions: InternalResolutions): JsonStructure =>

--- a/ark/type/__tests__/realWorld.test.ts
+++ b/ark/type/__tests__/realWorld.test.ts
@@ -1531,6 +1531,21 @@ date3 must be a parsable date (was "")`)
 		attest(result).equals({})
 	})
 
+	// https://github.com/arktypeio/arktype/issues/1640
+	it("cyclic discriminated union with record reference", () => {
+		const Node = scope({
+			Number: { type: "'number'" },
+			Array: { type: "'array'", item: "Node" },
+			Unit: { type: "'unit'" },
+			Container: { things: "Record<string, Node>" },
+			Node: "Number | Array | Unit"
+		}).export().Node
+
+		const data = { type: "array", item: { type: "number" } } as const
+
+		attest(Node(data)).equals(data)
+	})
+
 	// https://github.com/arktypeio/arktype/issues/1284
 	it("cyclic discriminated union issue 4", () => {
 		const ruleset = scope({


### PR DESCRIPTION
Fixes #1640.

When bootstrapping alias references, preserve references already present on the current node instead of overwriting them with same-id references from another scope. This keeps a recursive `$Array` alias bound to the user scope when another alias references `Record<string, Node>`.

Tests:
- `pnpm testTyped ark/type/__tests__/realWorld.test.ts --grep "cyclic discriminated union with record reference"`
- `pnpm testTyped ark/type/__tests__/realWorld.test.ts --grep "cyclic discriminated union"`
- `pnpm testTyped ark/type/__tests__/discrimination.test.ts`
- `pnpm testTyped ark/schema/__tests__/scope.test.ts ark/type/__tests__/scope.test.ts`