### PR TITLE
fix(schema, type): avoid ParseError on duplicate scope names and decouple parseCache

### DIFF
--- a/ark/schema/__tests__/scope.test.ts
+++ b/ark/schema/__tests__/scope.test.ts
@@ -87,4 +87,11 @@ contextualize(() => {
 			"a.b.a.b must be an object (was a string)"
 		)
 	})
+
+	it("allows multiple scopes with the same name without collision", () => {
+		const s1 = schemaScope({ a: { domain: "string" } }, { name: "Array" })
+		const s2 = schemaScope({ b: { domain: "number" } }, { name: "Array" })
+		attest(s1.name).equals("Array")
+		attest(s2.name).equals("Array")
+	})
 })

--- a/ark/schema/scope.ts
+++ b/ark/schema/scope.ts
@@ -150,7 +150,9 @@ export type writeDuplicateAliasError<alias extends string> =
 
 export type AliasDefEntry = [name: string, defValue: unknown]
 
-const scopesByName: Record<string, BaseScope | undefined> = {}
+// Fallback counter for anonymous scopes; scopes are identified by instance
+// identity rather than names to support HMR and multi-bundle environments.
+let anonymousScopeCount = 0
 
 export type GlobalOnlyConfigOptionName = satisfy<
 	keyof ArkSchemaConfig,
@@ -274,11 +276,7 @@ export abstract class BaseScope<$ extends {} = {}> {
 		this.resolvedConfig = mergeConfigs($ark.resolvedConfig, config)
 
 		this.name =
-			this.resolvedConfig.name ??
-			`anonymousScope${Object.keys(scopesByName).length}`
-		if (this.name in scopesByName)
-			throwParseError(`A Scope already named ${this.name} already exists`)
-		scopesByName[this.name] = this
+			this.resolvedConfig.name ?? `anonymousScope${anonymousScopeCount++}`
 
 		const aliasEntries = Object.entries(def).map(entry =>
 			this.preparseOwnAliasEntry(...entry)

--- a/ark/type/__tests__/scope.test.ts
+++ b/ark/type/__tests__/scope.test.ts
@@ -527,4 +527,17 @@ b.c.c must be an object (was missing)`)
 		attest(types.foo.json).snap({ domain: "string" })
 		attest(types.bar.json).snap({ domain: "number" })
 	})
+
+	it("allows multiple scopes with the same name without collision", () => {
+		const s1 = scope({ a: "string" }, { name: "Array" })
+		const s2 = scope({ a: "number" }, { name: "Array" })
+		attest((s1 as any).name).equals("Array")
+		attest((s2 as any).name).equals("Array")
+
+		// Verify parseCache does not cross-pollinate across scopes with the same name
+		const t1 = s1.type("a")
+		const t2 = s2.type("a")
+		attest(t1.expression).equals("string")
+		attest(t2.expression).equals("number")
+	})
 })

--- a/ark/type/parser/definition.ts
+++ b/ark/type/parser/definition.ts
@@ -2,6 +2,7 @@ import {
 	hasArkKind,
 	type BaseParseContext,
 	type BaseRoot,
+	type BaseScope,
 	type StandardSchemaV1
 } from "@ark/schema"
 import {
@@ -52,9 +53,7 @@ import {
 	type validateTupleLiteral
 } from "./tupleLiteral.ts"
 
-const parseCache: {
-	[cacheId: string]: { [def: string]: InnerParseResult } | undefined
-} = {}
+const parseCache = new WeakMap<BaseScope, Record<string, InnerParseResult>>()
 
 export const parseInnerDefinition = (
 	def: unknown,
@@ -66,7 +65,11 @@ export const parseInnerDefinition = (
 			// resolutions like "this" or generic args
 			return parseString(def, ctx)
 		}
-		const scopeCache = (parseCache[ctx.$.name] ??= {})
+		let scopeCache = parseCache.get(ctx.$)
+		if (!scopeCache) {
+			scopeCache = {}
+			parseCache.set(ctx.$, scopeCache)
+		}
 		return (scopeCache[def] ??= parseString(def, ctx))
 	}
 	return hasDomain(def, "object") ?


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `pnpm prChecks` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/arktypeio/arktype/blob/main/.github/CONTRIBUTING.md
-->

Resolves #1617 and unblocks https://github.com/yamcodes/arkenv/issues/895

### Summary

In `@ark/schema`, `BaseScope` previously threw `A Scope already named ${this.name} already exists` if a scope was registered with a name that was already recorded in `scopesByName`.

Because ArkType's built-in `arkArray` keyword module is initialized at module evaluation time with `{ name: "Array" }`, any dual-package hazard (e.g. `@ark/attest` running alongside another version of `arktype` in a monorepo) or Next.js/Vite HMR module re-evaluation would throw an uncatchable `ParseError: A Scope already named Array already exists` during startup.

This PR:
1. Removes the duplicate-name `throwParseError` in `@ark/schema/scope.ts` and uses a sequential monotonic counter (`anonymousScopeCount`) for anonymous scopes (dropping the dead `scopesByName` state).
2. Decouples `parseCache` in `@ark/type/parser/definition.ts` from scope names by keying on `BaseScope` identity using a `WeakMap<BaseScope, Record<string, InnerParseResult>>`. This ensures parse results are isolated per scope instance even if two scopes share the same name, and prevents memory leaks when temporary scopes are garbage-collected.
3. Adds unit tests in both `@ark/schema` and `arktype` asserting that scopes sharing the same name do not throw, and that `parseCache` does not leak between same-named scope instances.

### Why this approach over alternatives?

- **Why not just change `@ark/attest/package.json` (e.g. `peerDependencies` or bumping versions)?**
  Only changing `package.json` does not solve the root bug. Any time two slightly different versions of `arktype` coexist in a monorepo, or when a file is re-evaluated during dev-server HMR (Vite / Next.js), the built-in `Array` module would still throw a fatal startup crash. Changing `peerDependencies` also alters the installation contract for existing `@ark/attest` users and churns lockfiles.
- **Why use a `WeakMap` for `parseCache` instead of scope names?**
  When multiple scopes share the same name, string definitions parsed in one scope could leak into another. Keying the cache by `BaseScope` object reference guarantees 100% parse isolation per instance, and allows temporary scopes to be cleanly garbage-collected without memory leaks.

### Verification
- `pnpm lint`: passed with 0 warnings/errors.
- `pnpm prChecks`: passed completely locally (lint, buildRepo, tsc, mocha unit tests, V8 fast properties, integration tests, benchmark thresholds, and tsVersions tests: 1713 passing).